### PR TITLE
WMO topic hierarchy and minor fixes

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-story.md
+++ b/.github/ISSUE_TEMPLATE/user-story.md
@@ -1,9 +1,9 @@
 ---
 name: User story
 about: Use this template to document a user story
-title: 
-labels: 
-assignees: 
+title:
+labels:
+assignees:
 ---
 
 ## User story

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,8 @@
 name: docs
 on:
   push:
+    branches:
+    - main
     paths:
     - 'docs/**'
 

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -33,13 +33,13 @@ jobs:
         docker exec `docker ps -q --filter ancestor=wis2box_project_wis2box` sh -c " \
           wis2box environment create \
           && wis2box environment show \
-          && wis2box data setup --topic-hierarchy core.data.observations-surface-land.mw.FWCL.landFixed \
-          && wis2box data info --topic-hierarchy core.data.observations-surface-land.mw.FWCL.landFixed \
+          && wis2box data setup --topic-hierarchy data.core.observations-surface-land.mw.FWCL.landFixed \
+          && wis2box data info --topic-hierarchy data.core.observations-surface-land.mw.FWCL.landFixed \
           && wis2box metadata station cache /data/wis2box/data/metadata/station/station_list.csv \
           && wis2box metadata station publish-collection \
           && wis2box metadata discovery publish /data/wis2box/data/metadata/discovery/surface-weather-observations.yml \
-          && wis2box data ingest -th core.data.observations-surface-land.mw.FWCL.landFixed -p /data/wis2box/data/observations/WIGOS_0-454-2-AWSNAMITAMBO_20210707.csv \
-          && wis2box api add-collection /data/wis2box/data/metadata/discovery/surface-weather-observations.yml --topic-hierarchy core.data.observations-surface-land.mw.FWCL.landFixed \
+          && wis2box data ingest -th data.core.observations-surface-land.mw.FWCL.landFixed -p /data/wis2box/data/observations/WIGOS_0-454-2-AWSNAMITAMBO_20210707.csv \
+          && wis2box api add-collection /data/wis2box/data/metadata/discovery/surface-weather-observations.yml --topic-hierarchy data.core.observations-surface-land.mw.FWCL.landFixed \
           && wis2box api add-collection-items -r -p /data/wis2box/data/public"
     - name: run wis2box
       run: |

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -33,13 +33,13 @@ jobs:
         docker exec `docker ps -q --filter ancestor=wis2box_project_wis2box` sh -c " \
           wis2box environment create \
           && wis2box environment show \
-          && wis2box data setup --topic-hierarchy observations-surface-land.mw.FWCL.landFixed \
-          && wis2box data info --topic-hierarchy observations-surface-land.mw.FWCL.landFixed \
+          && wis2box data setup --topic-hierarchy core.data.observations-surface-land.mw.FWCL.landFixed \
+          && wis2box data info --topic-hierarchy core.data.observations-surface-land.mw.FWCL.landFixed \
           && wis2box metadata station cache /data/wis2box/data/metadata/station/station_list.csv \
           && wis2box metadata station publish-collection \
           && wis2box metadata discovery publish /data/wis2box/data/metadata/discovery/surface-weather-observations.yml \
-          && wis2box data ingest -th observations-surface-land.mw.FWCL.landFixed -p /data/wis2box/data/observations/WIGOS_0-454-2-AWSNAMITAMBO_20210707.csv \
-          && wis2box api add-collection /data/wis2box/data/metadata/discovery/surface-weather-observations.yml --topic-hierarchy observations-surface-land.mw.FWCL.landFixed \
+          && wis2box data ingest -th core.data.observations-surface-land.mw.FWCL.landFixed -p /data/wis2box/data/observations/WIGOS_0-454-2-AWSNAMITAMBO_20210707.csv \
+          && wis2box api add-collection /data/wis2box/data/metadata/discovery/surface-weather-observations.yml --topic-hierarchy core.data.observations-surface-land.mw.FWCL.landFixed \
           && wis2box api add-collection-items -r -p /data/wis2box/data/public"
     - name: run wis2box
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,14 +84,14 @@ Your contribution will be under our [license](https://github.com/wmo-im/wis2box/
       branch, __base your branch off the ``main`` one__.
 
 * Note that depending on how long it takes for the dev team to merge your
-  patch, the copy of ``main`` you worked off of may get out of date! 
+  patch, the copy of ``main`` you worked off of may get out of date!
     * If you find yourself 'bumping' a pull request that's been sidelined for a
       while, __make sure you rebase or merge to latest ``main/``__ to ensure a
         speedier resolution.
 
 ### Code Formatting
 
-* __Please follow the coding conventions and style used in the wis2box repository.__ 
+* __Please follow the coding conventions and style used in the wis2box repository.__
 * wis2box endeavours to follow the
   [PEP-8](http://www.python.org/dev/peps/pep-0008/) guidelines.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Reporting
 
-Security/vulnerability reports **should not** be submitted through GitHub issues or public discussions, but instead please send your report 
-to **tomkralidis nospam @ gmail.com** - (remove the blanks and 'nospam').  
+Security/vulnerability reports **should not** be submitted through GitHub issues or public discussions, but instead please send your report
+to **tomkralidis nospam @ gmail.com** - (remove the blanks and 'nospam').
 
 ## Supported Versions
 

--- a/docker/data-consumer/config/subscribe/gisc-ca.conf
+++ b/docker/data-consumer/config/subscribe/gisc-ca.conf
@@ -9,7 +9,7 @@ topic_prefix v03
 subtopic #
 
 #for development, want stuff to expire so you get a clean state.
-# 1 second/minute/hour/day/week 
+# 1 second/minute/hour/day/week
 # once a configuration is stopped the broker will remember the pending
 # queue, until it expires.
 expire 1m

--- a/docker/data-consumer/config/subscribe/gisc-de.conf.off
+++ b/docker/data-consumer/config/subscribe/gisc-de.conf.off
@@ -4,21 +4,21 @@
 #  Contact: Antje.Schremmer@dwd.de for credentials.
 #  to use with sarra, you need a line like so in credentials.conf:
 #    amqps://guest_canada:notReallyMyPassowrd@oflkd013.dwd.de login_method=PLAIN
-#  
+#
 #  The login_method=PLAIN specification is necessary because for some reason auto-negotiation fails.
 #  replace guest_canada in the credentials file and the broker below by the user name assigned.
-# 
+#
 broker amqps://guest_canada@oflkd013.dwd.de/
 
 acceptSizeWrong
-batch 1 
+batch 1
 #set sarracenia.moth.amqp.AMQP.logLevel debug
 #messageDebugDump
 
 reject .*/weather_reports/.*
 reject .*/webcam/.*
 
-strip 1 
+strip 1
 mirror
 directory ${WIS2BOX_DATADIR}/data/public/${YYYYMMDD}T${HH}
 accept .*

--- a/docker/docker-compose.webdav.yml
+++ b/docker/docker-compose.webdav.yml
@@ -11,6 +11,6 @@ services:
       PASSWORD: ${WEBDAV_PWD}
     ports:
       - 80:80
-    volumes:  
+    volumes:
       - ${WIS2BOX_DATADIR}/data/incoming:/var/lib/dav/data/incoming
       - ${WIS2BOX_DATADIR}/data/public:/var/lib/dav/data/public

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -87,7 +87,7 @@ services:
 
   wis2box:
     container_name: wis2box
-    build: 
+    build:
       context: ..
       args:
         WIS2BOX_PIP3_EXTRA_PACKAGES: ${WIS2BOX_PIP3_EXTRA_PACKAGES}

--- a/docker/pygeoapi/wait-for-elasticsearch.sh
+++ b/docker/pygeoapi/wait-for-elasticsearch.sh
@@ -38,7 +38,7 @@ response=$(curl $host)
 
 until [ "$response" = "200" ]  ; do
     response=$(curl --write-out %{http_code} --silent --output /dev/null "$host")
-    >&2 echo "Elasticsearch is up but unavailable - No Reponse - sleeping"
+    >&2 echo "Elasticsearch is up but unavailable - No Response - sleeping"
     sleep 10
 
 done

--- a/docs/source/administration.rst
+++ b/docs/source/administration.rst
@@ -7,7 +7,7 @@ wis2box is designed to be built as a network of virtual machines within a virtua
 is built, users login into the main wis2box machine to setup their workflow and configurations for
 data processing and publishing.
 
-The `wis2box-ctl.py` utility provides a number of tools for managing the wis2box containers.
+The ``wis2box-ctl.py`` utility provides a number of tools for managing the wis2box containers.
 
 The following steps provide an example of container management workflow.
 
@@ -24,7 +24,7 @@ The following steps provide an example of container management workflow.
 
    # view status of all deployed containers
    python3 wis2box-ctl.py status
-  
+
 
 .. note::
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'nature'
+html_theme = 'sphinx_wmo_theme'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -81,7 +81,7 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_wmo_theme'
+html_theme = 'nature'
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -85,7 +85,7 @@ PubSub configuration provides connectivity information for the PubSub broker.
 Other
 ^^^^^
 
-Additional directives provide various configurationscontrol of configuration options for the deployment of wis2box.  
+Additional directives provide various configurationscontrol of configuration options for the deployment of wis2box.
 
 .. code-block:: bash
 

--- a/docs/source/extending-wis2box.rst
+++ b/docs/source/extending-wis2box.rst
@@ -26,9 +26,9 @@ located in ``wis2box/data/base.py``.  Any wis2box plugin needs to inherit from
         """Observation data"""
         def __init__(self, topic_hierarchy: str) -> None:
             super().__init__(topic_hierarchy)
-    
+
         def transform(self, input_data: Path) -> bool:
-            # transform data 
+            # transform data
             # populate self.output_data with a dict as per:
             self.output_data [{
                 '_meta': {

--- a/docs/source/how-wis2box-works.rst
+++ b/docs/source/how-wis2box-works.rst
@@ -5,9 +5,9 @@ How wis2box works
 
 wis2box is implemented in the spirit of the `Twelve-Factor App methodology`_.
 
-wis2box is a `Docker`_ and `Python`_-based platform with the capabilities 
-for centres to integrate their data holdings and publish them to 
-the WMO Information System with a plug and play capability supporting 
+wis2box is a `Docker`_ and `Python`_-based platform with the capabilities
+for centres to integrate their data holdings and publish them to
+the WMO Information System with a plug and play capability supporting
 data publishing, discovery and access.
 
 High level system context

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -14,14 +14,14 @@ Core dependencies are installed as containers in the Docker Compose deployment o
 is true for the software wis2box itself, which runs as a container orchestrating the necessary
 data management workflows of a node as part of the WIS 2.0 network.
 
-Once Python and Docker are installed, wis2box needs to be installed. 
+Once Python and Docker are installed, wis2box needs to be installed.
 
 ZIP Archive
 -----------
 
 .. code-block:: bash
 
-    # curl, wget or download from your web browser 
+    # curl, wget or download from your web browser
     curl https://github.com/wmo-im/wis2box/archive/refs/heads/main.zip
     cd wis2box-main
 
@@ -39,7 +39,7 @@ Summary
 -------
 
 Congratulations! Whichever of the abovementioned methods you chose, you have successfully installed wis2box
-onto your system. From here, you can get started with test data by following the :ref:`quickstart`, or continue on to 
+onto your system. From here, you can get started with test data by following the :ref:`quickstart`, or continue on to
 :ref:`configuration`.
 
 .. _`Python`: https://www.python.org/downloads

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -3,7 +3,7 @@
 Quickstart
 ==========
 
-Download wis2box and start wis2box using Malawi test data.   
+Download wis2box and start using Malawi test data:
 
 .. code-block:: bash
 
@@ -11,18 +11,20 @@ Download wis2box and start wis2box using Malawi test data.
     cd wis2box
 
 
-For the purposes of a quickstart, this deployment expects the test environment, which includes data and metadata. This is done by using the test environment file.
+For the purposes of a quickstart, this deployment expects the test environment, which includes data and metadata. This
+is done by using the test environment file:
 
 .. code-block:: bash
 
     cp tests/test.env dev.env
     vi dev.env
 
+
 .. note::
 
-    For deployment of wis2box otherwise, see :ref:`configuration`
+    For more information on deployment, see :ref:`administration` and :ref:`configuration`
 
-Start wis2box with Docker Compose and login to the wis2box container
+Start wis2box with Docker Compose and login to the wis2box container:
 
 .. code-block:: bash
 
@@ -30,48 +32,53 @@ Start wis2box with Docker Compose and login to the wis2box container
     python3 wis2box-ctl.py login
 
 
-Inside create the enviroment inside docker and ensure it is correct. 
+Once logged in, create the enviroment and verify it is correct:
 
 .. code-block:: bash
 
     wis2box environment create
     wis2box environment show
 
-Setup observation data processing and api publication.
+
+Setup observation data processing and API publication:
 
 .. code-block:: bash
 
     wis2box data setup --topic-hierarchy observations-surface-land.mw.FWCL.landFixed
     wis2box api add-collection /data/wis2box/data/metadata/discovery/surface-weather-observations.yml --topic-hierarchy observations-surface-land.mw.FWCL.landFixed
 
-Publish metadata discovery and generate station collection.
+
+Publish station collection and discovery metadata to the API:
 
 .. code-block:: bash
 
-    wis2box metadata discovery publish /data/wis2box/data/metadata/discovery/surface-weather-observations.yml 
     wis2box metadata station cache /data/wis2box/data/metadata/station/station_list.csv
-    wis2box metadata station generate-collection
+    wis2box metadata station publish-collection
+    wis2box metadata discovery publish /data/wis2box/data/metadata/discovery/surface-weather-observations.yml
 
-Process data via CLI
+
+Process data via CLI:
 
 .. code-block:: bash
 
-    wis2box data ingest -th observations-surface-land.mw.FWCL.landFixed -p /data/wis2box/data/observations/0-454-2-AWSNAMITAMBO-20210707.csv
-    wis2box api add-collections-items -r -p /data/wis2box/data/public
-    
-Log out of wis2box container
+    wis2box data ingest --topic-hierarchy observations-surface-land.mw.FWCL.landFixed --path /data/wis2box/data/observations/0-454-2-AWSNAMITAMBO-20210707.csv
+    wis2box api add-collection-items --recursive --path /data/wis2box/data/public
+
+
+Logout of wis2box container:
 
 .. code-block:: bash
 
     exit
 
-Restart wis2box
+Restart wis2box:
 
 .. code-block:: bash
 
     python3 wis2box-ctl.py start
 
 
-From here you can run python3 wis2box-ctl.py status to confirm containers are running. 
-In browser you should be able to open http://localhost:8999 as well as 
+From here, you can run ``python3 wis2box-ctl.py`` to confirm that containers are running.
+
+In your web browser you should be able to open http://localhost:8999 as well as
 http://localhost:8999/pygeoapi/collections to further explore wis2box.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -44,8 +44,8 @@ Setup observation data processing and API publication:
 
 .. code-block:: bash
 
-    wis2box data setup --topic-hierarchy observations-surface-land.mw.FWCL.landFixed
-    wis2box api add-collection /data/wis2box/data/metadata/discovery/surface-weather-observations.yml --topic-hierarchy observations-surface-land.mw.FWCL.landFixed
+    wis2box data setup --topic-hierarchy data.core.observations-surface-land.mw.FWCL.landFixed
+    wis2box api add-collection /data/wis2box/data/metadata/discovery/surface-weather-observations.yml --topic-hierarchy data.core.observations-surface-land.mw.FWCL.landFixed
 
 
 Publish station collection and discovery metadata to the API:
@@ -61,7 +61,7 @@ Process data via CLI:
 
 .. code-block:: bash
 
-    wis2box data ingest --topic-hierarchy observations-surface-land.mw.FWCL.landFixed --path /data/wis2box/data/observations/0-454-2-AWSNAMITAMBO-20210707.csv
+    wis2box data ingest --topic-hierarchy data.core.observations-surface-land.mw.FWCL.landFixed --path /data/wis2box/data/observations/0-454-2-AWSNAMITAMBO-20210707.csv
     wis2box api add-collection-items --recursive --path /data/wis2box/data/public
 
 

--- a/docs/source/running/api-publishing.rst
+++ b/docs/source/running/api-publishing.rst
@@ -61,7 +61,7 @@ driven workflow.  If manual ingest is needed, the following command can be run i
 API container restart
 ---------------------
 
-Any change to API configuration requires a restart of the API container, which can be fun via the following:
+Any change to API configuration requires a restart of the API container, which can be run via the following:
 
 .. code-block:: bash
 

--- a/docs/source/running/api-publishing.rst
+++ b/docs/source/running/api-publishing.rst
@@ -58,6 +58,14 @@ driven workflow.  If manual ingest is needed, the following command can be run i
 
    wis2box api add-collection-items --topic-hierarchy foo.bar.baz
 
+API container restart
+---------------------
+
+Any change to API configuration requires a restart of the API container, which can be fun via the following:
+
+.. code-block:: bash
+
+   python wis2box-ctl.py restart wis2box
 
 
 .. _`OGC API`: https://ogcapi.ogc.org

--- a/docs/source/running/api-publishing.rst
+++ b/docs/source/running/api-publishing.rst
@@ -65,7 +65,7 @@ Any change to API configuration requires a restart of the API container, which c
 
 .. code-block:: bash
 
-   python wis2box-ctl.py restart wis2box
+   python3 wis2box-ctl.py restart wis2box
 
 
 .. _`OGC API`: https://ogcapi.ogc.org

--- a/docs/source/running/data-ingest-processing-and-publishing.rst
+++ b/docs/source/running/data-ingest-processing-and-publishing.rst
@@ -20,7 +20,7 @@ Explicit topic hierarchy workflow
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: bash
-   
+
    # process a single CSV file
    wis2box data ingest --topic-hierarchy foo.bar.baz -p /path/to/file.csv
 

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,11 @@ setup(
         'Topic :: Scientific/Engineering :: GIS',
         'Topic :: Scientific/Engineering :: Information Analysis'
     ],
+    project_urls={
+        'Homepage': 'https://wmo-im.github.io/wis2box',
+        'Source Code': 'https://github.com/wmo-im/wis2box',
+        'Issue Tracker': 'https://github.com/wmo-im/wis2box/issues'
+    },
     cmdclass={'test': PyTest},
     test_suite='tests.run_tests'
 )

--- a/tests/data/metadata/discovery/surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/surface-weather-observations.yml
@@ -34,7 +34,7 @@ identification:
     keywords:
         default:
             keywords:
-                en: 
+                en:
                     - surface weather
                     - temperature
                     - observations
@@ -56,7 +56,7 @@ identification:
                 name:
                     en: WMO Core Metadata profile topic hierarchy
                 url: https://github.com/wmo-im/wcmp2-codelists/blob/main/codelists/topic_hierarchy.csv
-        
+
     topiccategory:
         - climatologyMeteorologyAtmosphere
     extents:

--- a/tests/data/metadata/discovery/surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/surface-weather-observations.yml
@@ -1,6 +1,6 @@
 wis2box:
     retention: P30D
-    topic_hierarchy: observations-surface-land.mw.FWCL.landFixed
+    topic_hierarchy: data.core.observations-surface-land.mw.FWCL.landFixed
     data_category: observationsSurfaceLand
     country_code: mw
     originator: FWCL
@@ -10,7 +10,7 @@ mcf:
     version: 1.0
 
 metadata:
-    identifier: observations-surface-land.mw.FWCL.landFixed
+    identifier: data.core.observations-surface-land.mw.FWCL.landFixed
     language: en
     language_alternate: fr
     charset: utf8

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -80,7 +80,7 @@ def walk_path(path: str) -> list:
 
 def make(command: str, *args) -> None:
     """
-    Serves as pseudo Makefile using python subprocesses.
+    Serves as pseudo Makefile using Python subprocesses.
 
     :param command: required, string. Make command.
 

--- a/wis2box/data/__init__.py
+++ b/wis2box/data/__init__.py
@@ -166,6 +166,9 @@ def clean(ctx, days, verbosity):
 def info(ctx, topic_hierarchy, verbosity):
     """Display data properties"""
 
+    if topic_hierarchy is None:
+        raise click.ClickException('Missing -th/--topic-hierarchy')
+
     result = show_info(topic_hierarchy)
     click.echo(json.dumps(result, default=json_serial, indent=4))
 
@@ -176,6 +179,9 @@ def info(ctx, topic_hierarchy, verbosity):
 @cli_helpers.OPTION_VERBOSITY
 def setup(ctx, topic_hierarchy, verbosity):
     """Setup data directories"""
+
+    if topic_hierarchy is None:
+        raise click.ClickException('Missing -th/--topic-hierarchy')
 
     result = setup_dirs(topic_hierarchy)
     click.echo('Directories created:')

--- a/wis2box/resources/data-mappings.yml
+++ b/wis2box/resources/data-mappings.yml
@@ -1,3 +1,3 @@
 
 data:
-    observations-surface-land.mw.FWCL.landFixed: wis2box.data.observations.ObservationData
+    data.core.observations-surface-land.mw.FWCL.landFixed: wis2box.data.observations.ObservationData

--- a/wis2box/topic_hierarchy.py
+++ b/wis2box/topic_hierarchy.py
@@ -80,7 +80,7 @@ def validate_and_load(topic_hierarchy: str,
         raise ValueError(msg)
 
     if not fuzzy:
-        if th.dotpath not in DATADIR_DATA_MAPPINGS['data'].keys():
+        if th.dotpath not in DATADIR_DATA_MAPPINGS['data']:
             msg = 'Topic hierarchy not in data mappings'
             LOGGER.error(msg)
             raise ValueError(msg)


### PR DESCRIPTION
This PR adds a number of minor fixes:

- trailing spaces ijn files
- documentation
- adds top level WMO topic hierarchy to example paths (i.e. `data.core`)
- only publish live documentation on changes to `main` branch