### PR TITLE
Arg build fix

### DIFF
--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -133,7 +133,7 @@ def make(args) -> None:
     if args.command == "config":
         run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} config'))
     elif args.command == "build":
-        cmd = "" if not args.args else args.args
+        cmd = "" if not args.args else ' '.join(args.args)
         run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} build {cmd}'))
     elif args.command == "start":
         run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} up -d'))
@@ -160,11 +160,11 @@ def make(args) -> None:
         _ = run(args, split('docker ps -a -q'), asciiPipe=True)
         run(args, split(f'docker rm {_}'))
     elif args.command == "restart":
-        container = "" if not args.args else args.args
+        container = "" if not args.args else ' '.joins(args.args)
         run(args,
             split(f'docker-compose {DOCKER_COMPOSE_ARGS} restart {container}'))
     elif args.command == "status":
-        cmd = "" if not args.args else args.args
+        cmd = "" if not args.args else ' '.join(args.args)
         run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} ps {cmd}'))
     elif args.command == "lint":
         files = walk_path(".")

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -44,8 +44,16 @@ parser.add_argument(
     help='simulate execution by printing action rather than executing')
 
 commands = [
-    'config', 'build', 'start', 'stop', 'update', 'prune', 'restart', 'status',
-    'lint'
+    'build',
+    'config',
+    'lint',
+    'login',
+    'prune',
+    'restart',
+    'start',
+    'status',
+    'stop',
+    'update',
 ]
 
 parser.add_argument('command',


### PR DESCRIPTION
./wis2box-ctl.py build wis2box 

was failing because additional args supplied as list, instead of concatenated into a single string.