### PR TITLE
remove "gather" log messages from data-consumer and wis2box containers.

### DIFF
--- a/docker/data-consumer/config/watch/incoming.conf
+++ b/docker/data-consumer/config/watch/incoming.conf
@@ -4,7 +4,7 @@ post_exchange xs_wis2box_acquisition
 
 # to see can see entire messages:
 #logMessageDump True
-logEvents all
+logEvents after_accept,after_work
 
 # 'remove' events would confuse the consumers, so do not generate events for that.
 events create,modify,link

--- a/docker/wis2box/config/subscribe/data-api-publish.conf
+++ b/docker/wis2box/config/subscribe/data-api-publish.conf
@@ -8,6 +8,6 @@ accept .*.geojson$
 accept_unmatched off
 callback log
 
-logEvents all
+logEvents after_accept,after_work
 
 flowcb wis2box.event.data_api_publish.Event

--- a/docker/wis2box/config/subscribe/data-ingest.conf
+++ b/docker/wis2box/config/subscribe/data-ingest.conf
@@ -8,7 +8,6 @@ accept .*
 callback log
 
 logMessageDump True
-
 logEvents after_accept,after_work
 
 flowcb wis2box.event.data_ingest.Event


### PR DESCRIPTION
sr3 log setting to omit those messages (corresponding to every time a source is polled.)
the new log setting is to log when a message is received, and then when the action on the message is performed.
