### PR TITLE
for testing and development, it is just annoying to have old files ignored

### DIFF
--- a/docker/data-consumer/config/watch/incoming.conf
+++ b/docker/data-consumer/config/watch/incoming.conf
@@ -6,6 +6,11 @@ post_exchange xs_wis2box_acquisition
 #logMessageDump True
 logEvents after_accept,after_work
 
+#in ops, want to ignore files that are too old (remove following line.)
+#for testing/dev, do not care how old the files are.
+nodupe_fileAgeMax 0
+
+
 # 'remove' events would confuse the consumers, so do not generate events for that.
 events create,modify,link
 


### PR DESCRIPTION
With this setting change... no matter how old a file is when copied into the incoming directory,
it will be accepted and posted.
