### PR TITLE
Mqp cfg tweaks... did some mqp message inspection for ca and mw products

### DIFF
--- a/docker/ca-republisher/config/default.conf
+++ b/docker/ca-republisher/config/default.conf
@@ -1,2 +1,3 @@
 logLevel ${WIS2BOX_LOGGING_LOGLEVEL}
+logEvents after_accept,after_work
 logStdout

--- a/docker/ca-republisher/config/subscribe/ca-republisher.conf
+++ b/docker/ca-republisher/config/subscribe/ca-republisher.conf
@@ -50,5 +50,5 @@ accept_unmatched on
 #instances 5
 post_broker  ${WIS2BOX_BROKER}
 post_exchange xpublic
-post_baseUrl ${WIS2BOX_URL}/data
-post_baseDir ${WIS2BOX_DATADIR}/data/public
+post_baseUrl ${WIS2BOX_URL}/data/${baseUrlPathLast}
+post_baseDir ${WIS2BOX_DATADIR}/data/public/${baseUrlPathLast}

--- a/docker/data-consumer/config/default.conf
+++ b/docker/data-consumer/config/default.conf
@@ -1,2 +1,3 @@
 logLevel ${WIS2BOX_LOGGING_LOGLEVEL}
+logEvents after_accept,after_work
 logStdout

--- a/docker/data-consumer/config/watch/incoming.conf
+++ b/docker/data-consumer/config/watch/incoming.conf
@@ -4,7 +4,6 @@ post_exchange xs_wis2box_acquisition
 
 # to see can see entire messages:
 #logMessageDump True
-logEvents after_accept,after_work
 
 #in ops, want to ignore files that are too old (remove following line.)
 #for testing/dev, do not care how old the files are.

--- a/docker/de-republisher/config/default.conf
+++ b/docker/de-republisher/config/default.conf
@@ -1,2 +1,3 @@
 logLevel ${WIS2BOX_LOGGING_LOGLEVEL}
+logEvents after_accept,after_work
 logStdout

--- a/docker/default.env
+++ b/docker/default.env
@@ -14,11 +14,11 @@ WIS2BOX_LOGGING_LOGLEVEL=ERROR
 WIS2BOX_LOGGING_LOGFILE=stdout
 
 # PubSub
-WIS2BOX_BROKER=mqtt://wis2box:wis2box@mosquitto/
+WIS2BOX_BROKER=mqtt://wis2box:wis2box@mosquitto
 
 # other
 WIS2BOX_OSCAR_API_TOKEN=some_token
-WIS2BOX_URL=http://localhost:8999/
+WIS2BOX_URL=http://localhost:8999
 
 # mappings of topic hierarchy to wis2box data plugins
 # optionally override default mappings from wis2box data plugins

--- a/docker/mqp-publisher/config/default.conf
+++ b/docker/mqp-publisher/config/default.conf
@@ -1,2 +1,3 @@
 logLevel ${WIS2BOX_LOGGING_LOGLEVEL}
+logEvents after_accept,after_work
 logStdout

--- a/docker/mqp-publisher/config/subscribe/public.conf
+++ b/docker/mqp-publisher/config/subscribe/public.conf
@@ -5,9 +5,7 @@ subtopic #
 mirror True
 accept .*
 accept_unmatched off
-callback log
-logEvents all
 post_broker ${WIS2BOX_BROKER}
 post_exchange xpublic
-post_baseUrl ${WIS2BOX_URL}/data
-post_baseDir ${WIS2BOX_DATADIR}/data/public
+post_baseUrl ${WIS2BOX_URL}/data/${baseUrlPathLast}
+post_baseDir ${WIS2BOX_DATADIR}/data/public/${baseUrlPathLast}

--- a/docker/wis2box/config/default.conf
+++ b/docker/wis2box/config/default.conf
@@ -1,2 +1,3 @@
 logLevel ${WIS2BOX_LOGGING_LOGLEVEL}
+logEvents after_accept,after_work
 logStdout

--- a/docker/wis2box/config/subscribe/data-api-publish.conf
+++ b/docker/wis2box/config/subscribe/data-api-publish.conf
@@ -6,8 +6,5 @@ subtopic #
 mirror True
 accept .*.geojson$
 accept_unmatched off
-callback log
-
-logEvents after_accept,after_work
 
 flowcb wis2box.event.data_api_publish.Event

--- a/docker/wis2box/config/subscribe/data-ingest.conf
+++ b/docker/wis2box/config/subscribe/data-ingest.conf
@@ -5,10 +5,8 @@ instances 2
 subtopic #
 mirror True
 accept .*
-callback log
 
 logMessageDump True
-logEvents after_accept,after_work
 
 flowcb wis2box.event.data_ingest.Event
 


### PR DESCRIPTION
The date directory is now in the baseURL as specified by TT-Protocols group.
Confirmed that part was correct for both republishing from CA- fake gisc, and 
local products for Malawi.

next step is to produce data-access jupyter examples.
