### PR TITLE
Add phenomenonTime requirement

### DIFF
--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python3 wis2box-ctl.py build
         python3 wis2box-ctl.py start
+        sleep 5
         python3 wis2box-ctl.py status
     - name: generate wis2box collection
       run: |

--- a/wis2box/api/__init__.py
+++ b/wis2box/api/__init__.py
@@ -56,7 +56,9 @@ def generate_collection_metadata(mcf: dict) -> dict:
         'title': generated['properties']['title'],
         'description': generated['properties']['description'],
         'keywords': record['identification']['keywords'],
-        'extents': generated['properties']['extent'],
+        'extents': {
+            'spatial': generated['properties']['extent']['spatial']
+        },
         'links': generated['associations'],
         'providers': []
     }

--- a/wis2box/api/backend/elastic.py
+++ b/wis2box/api/backend/elastic.py
@@ -127,7 +127,7 @@ class ElasticBackend(BaseBackend):
             'type': 'feature',
             'name': 'Elasticsearch',
             'data': f'{self.url}/{es_index}.*',
-            'id_field': 'identifier',
+            'id_field': 'id',
             'time_field': 'phenomenonTime'
         }
 
@@ -177,6 +177,7 @@ class ElasticBackend(BaseBackend):
 
             for feature in features:
                 es_index2 = es_index
+                feature['properties']['id'] = feature['id']
                 if self._is_dataset(collection_id):
                     LOGGER.debug('Determinining index date from OM GeoJSON')
                     date_ = parse_date(feature['properties']['phenomenonTime'])

--- a/wis2box/api/backend/elastic.py
+++ b/wis2box/api/backend/elastic.py
@@ -50,8 +50,7 @@ SETTINGS = {
                             'raw': {
                                 'type': 'keyword'
                             }
-                        },
-                        'format': 'strict_date_hour_minute||strict_date_time'
+                        }
                     }
                 }
             }
@@ -128,7 +127,7 @@ class ElasticBackend(BaseBackend):
             'type': 'feature',
             'name': 'Elasticsearch',
             'data': f'{self.url}/{es_index}.*',
-            'id_field': 'id',
+            'id_field': 'identifier',
             'time_field': 'phenomenonTime'
         }
 
@@ -178,7 +177,6 @@ class ElasticBackend(BaseBackend):
 
             for feature in features:
                 es_index2 = es_index
-                feature['properties']['id'] = feature['id']
                 if self._is_dataset(collection_id):
                     LOGGER.debug('Determinining index date from OM GeoJSON')
                     date_ = parse_date(feature['properties']['phenomenonTime'])

--- a/wis2box/api/backend/elastic.py
+++ b/wis2box/api/backend/elastic.py
@@ -41,6 +41,19 @@ SETTINGS = {
         'properties': {
             'geometry': {
                 'type': 'geo_shape'
+            },
+            'properties': {
+                'properties': {
+                    'phenomenonTime': {
+                        'type': 'date',
+                        'fields': {
+                            'raw': {
+                                'type': 'keyword'
+                            }
+                        },
+                        'format': 'strict_date_hour_minute||strict_date_time'
+                    }
+                }
             }
         }
     }
@@ -49,6 +62,7 @@ SETTINGS = {
 
 class ElasticBackend(BaseBackend):
     """Elasticsearch API backend"""
+
     def __init__(self, defs: dict) -> None:
         """
         initializer
@@ -114,7 +128,8 @@ class ElasticBackend(BaseBackend):
             'type': 'feature',
             'name': 'Elasticsearch',
             'data': f'{self.url}/{es_index}.*',
-            'id_field': 'id'
+            'id_field': 'id',
+            'time_field': 'phenomenonTime'
         }
 
     def delete_collection(self, collection_id: str) -> None:


### PR DESCRIPTION
Observation collections published to the OAPI with the ElasticSearch backend require defining the field: `phenomenonTime` in the geoJSON properties block. This is required to sort observations by date with the API.  The required field: `phenomenonTime` refers to the time of the observation. The optional field: `resultTime` refers to the time the observation was published.