### PR TITLE
Use line feed end of line character in shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior,
+# in case people don't have core.autocrlf set.
+* text=auto
+
+# Declares that files will always have CRLF line ends
+*.sh text eol=lf


### PR DESCRIPTION
Was working with @chenxiaoxia2019 on issues with Mosquito and pygeoapi containers getting the error:
```
standard_init_linux.go:228: exec user process caused: no such file or directory
```
The solution is add a behavior in `.gitattributes` for end of line characters of `.sh`/shell scripts to use the line feed (LF) character.