### PR TITLE
Pass wis2box urls to wis2box-ui

### DIFF
--- a/docker/default.env
+++ b/docker/default.env
@@ -15,6 +15,7 @@ WIS2BOX_LOGGING_LOGFILE=stdout
 
 # PubSub
 WIS2BOX_BROKER=mqtt://wis2box:wis2box@mosquitto
+WIS2BOX_MQTT_URL=mqtt://localhost:1883
 
 # other
 WIS2BOX_OSCAR_API_TOKEN=some_token

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,6 +17,9 @@ services:
   wis2box-ui:
     container_name: wis2box-ui
     image: ghcr.io/wmo-im/wis2box-ui:latest
+    env_file:
+      - default.env
+      - ../dev.env
     depends_on:
       - pygeoapi
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -96,6 +96,7 @@ PubSub configuration provides connectivity information for the PubSub broker.
 .. code-block:: bash
 
     WIS2BOX_BROKER=mqtt://wis2box:wis2box@mosquitto/  # RFC 1738 syntax of internal broker endpoint
+    WIS2BOX_MQTT_URL=mqtt://localhost:1883 # public MQTT url
 
 
 Other

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -60,7 +60,7 @@ wis2box. The default relationship below resembles the directory structure within
 
 .. code-block:: bash
 
-    WIS2BOX_HOST_DATADIR=${PWD}/wis2box-data # wis2box host data directory
+    WIS2BOX_HOST_DATADIR=${PWD}/wis2box-data  # wis2box host data directory
     WIS2BOX_DATADIR=/data/wis2box  # wis2box data directory
     WIS2BOX_DATA_RETENTION_DAYS=7  # wis2box data retention time, in days. Data older than this value is
                                    # is deleted on a daily basis
@@ -96,7 +96,7 @@ PubSub configuration provides connectivity information for the PubSub broker.
 .. code-block:: bash
 
     WIS2BOX_BROKER=mqtt://wis2box:wis2box@mosquitto/  # RFC 1738 syntax of internal broker endpoint
-    WIS2BOX_MQTT_URL=mqtt://localhost:1883 # public MQTT url
+    WIS2BOX_MQTT_URL=mqtt://localhost:1883  # public MQTT url
 
 
 Other

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -11,14 +11,13 @@ Download wis2box and start using Malawi test data:
     cd wis2box
 
 
-For the purposes of a quickstart, this deployment expects the test environment, which includes data and metadata. This
+For the purposes of a quickstart, this deployment expects the test environment, which includes data and metadata, and runs on localhost. This
 is done by using the test environment file:
 
 .. code-block:: bash
 
     cp tests/test.env dev.env
     vi dev.env
-    # ensure WIS2BOX_HOST_DATADIR is set to a local path on disk for persistent storage
 
 
 .. note::


### PR DESCRIPTION
- Pass URLs defined in `default.env` and `dev.env` to wis2box-ui.
- Add some clarification to docs that URLs defined in `default.env` need to be defined in `dev.env` when using remote host.