### PR TITLE
packaging requires separate installation of python modules to support…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update -y \
     # install wis2box dependencies
     && pip3 install https://github.com/wmo-im/csv2bufr/archive/dev.zip \
     && pip3 install https://github.com/geopython/pygeometa/archive/master.zip \
-    && pip3 install https://github.com/metpx/sarracenia/archive/v03_wip.zip \
+    && pip3 install https://github.com/MetPX/sarracenia/archive/refs/tags/v3.00.14.zip \
     # install wis2box
     && cd /app \
     && python3 setup.py install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN if [ "$WIS2BOX_PIP3_EXTRA_PACKAGES" = "None" ]; \
 # TODO: remove build packages for a smaller image
 RUN apt-get update -y \
     && apt-get install -y ${BUILD_PACKAGES} \
-    && apt-get install -y bash vim git python3-pip python3-dev curl libffi-dev libeccodes0 python3-eccodes python3-cryptography libssl-dev libudunits2-0 \
+    && apt-get install -y bash vim git python3-pip python3-dev curl libffi-dev libeccodes0 python3-eccodes python3-cryptography libssl-dev libudunits2-0 python3-amqp python3-paho-mqtt python3-netifaces python3-dateparser python3-tz \
     # install wis2box dependencies
     && pip3 install https://github.com/wmo-im/csv2bufr/archive/dev.zip \
     && pip3 install https://github.com/geopython/pygeometa/archive/master.zip \

--- a/wis2box/data/base.py
+++ b/wis2box/data/base.py
@@ -103,9 +103,6 @@ class BaseAbstractData:
             for key2, value2 in value.items():
                 if key2 == '_meta':
                     continue
-                if value2 is None:
-                    LOGGER.debug(f'No data; skipping')
-                    continue
                 filename = DATADIR_PUBLIC / (rfp) / key
                 filename = filename.with_suffix(f'.{key2}')
 
@@ -133,6 +130,8 @@ class BaseAbstractData:
             rfp = value['_meta']['relative_filepath']
             for key2, value2 in value.items():
                 if key2 == '_meta':
+                    continue
+                if value2 is None:
                     continue
                 filename = DATADIR_PUBLIC / (rfp) / key
                 yield filename.with_suffix(f'.{key2}')


### PR DESCRIPTION
to use metpx-sr3 3.0.15 or later versions, dependencies for optional deatures must be manually installed.
This was formerly done with mandatory dependencies, which caused portability issues.
