### PR TITLE
Use correct links in discovery metadata

### DIFF
--- a/wis2box/env.py
+++ b/wis2box/env.py
@@ -54,14 +54,7 @@ OSCAR_API_TOKEN = os.environ.get('WIS2BOX_OSCAR_API_TOKEN')
 URL = os.environ.get('WIS2BOX_URL')
 
 BROKER = os.environ.get('WIS2BOX_BROKER')
-MQTT_URL = os.environ.get('WIS2BOX_MQTT_URL')
-broker_url = urlparse(BROKER)
-if broker_url.port is not None:
-    broker_url_port = f':{broker_url.port}'
-else:
-    broker_url_port = ''
-
-MQP_URL = f'{broker_url.scheme}://{broker_url.hostname}{broker_url_port}/'
+MQP_URL = os.environ.get('WIS2BOX_MQTT_URL')
 
 try:
     DATA_RETENTION_DAYS = int(os.environ.get('WIS2BOX_DATA_RETENTION_DAYS'))
@@ -93,7 +86,6 @@ if None in [
     API_TYPE,
     API_URL,
     MQP_URL,
-    MQTT_URL,
     URL
 ]:
     msg = 'Environment variables not set!'

--- a/wis2box/env.py
+++ b/wis2box/env.py
@@ -54,7 +54,7 @@ OSCAR_API_TOKEN = os.environ.get('WIS2BOX_OSCAR_API_TOKEN')
 URL = os.environ.get('WIS2BOX_URL')
 
 BROKER = os.environ.get('WIS2BOX_BROKER')
-MQP_URL = os.environ.get('WIS2BOX_MQTT_URL')
+MQTT_URL = os.environ.get('WIS2BOX_MQTT_URL')
 
 try:
     DATA_RETENTION_DAYS = int(os.environ.get('WIS2BOX_DATA_RETENTION_DAYS'))
@@ -85,7 +85,7 @@ if None in [
     OSCAR_API_TOKEN,
     API_TYPE,
     API_URL,
-    MQP_URL,
+    MQTT_URL,
     URL
 ]:
     msg = 'Environment variables not set!'

--- a/wis2box/env.py
+++ b/wis2box/env.py
@@ -23,7 +23,6 @@ import click
 import logging
 import os
 from pathlib import Path
-from urllib.parse import urlparse
 
 from wis2box import cli_helpers
 from wis2box.util import yaml_load

--- a/wis2box/env.py
+++ b/wis2box/env.py
@@ -54,6 +54,7 @@ OSCAR_API_TOKEN = os.environ.get('WIS2BOX_OSCAR_API_TOKEN')
 URL = os.environ.get('WIS2BOX_URL')
 
 BROKER = os.environ.get('WIS2BOX_BROKER')
+MQTT_URL = os.environ.get('WIS2BOX_MQTT_URL')
 broker_url = urlparse(BROKER)
 if broker_url.port is not None:
     broker_url_port = f':{broker_url.port}'
@@ -92,6 +93,7 @@ if None in [
     API_TYPE,
     API_URL,
     MQP_URL,
+    MQTT_URL,
     URL
 ]:
     msg = 'Environment variables not set!'

--- a/wis2box/metadata/discovery.py
+++ b/wis2box/metadata/discovery.py
@@ -28,7 +28,7 @@ from pygeometa.schemas.ogcapi_records import OGCAPIRecordOutputSchema
 from wis2box import cli_helpers
 from wis2box.api.backend import load_backend
 from wis2box.api.config import load_config
-from wis2box.env import API_URL, MQTT_URL
+from wis2box.env import API_URL, MQP_URL
 from wis2box.metadata.base import BaseMetadata
 
 LOGGER = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class DiscoveryMetadata(BaseMetadata):
 
         LOGGER.debug('Adding distribution links')
         oafeat_link = {
-            'url': f"{API_URL}/collections/items/{identifier}",
+            'url': f"{API_URL}/collections/{identifier}",
             'type': 'OAFeat',
             'name': identifier,
             'description': identifier,
@@ -61,7 +61,7 @@ class DiscoveryMetadata(BaseMetadata):
         }
 
         mqp_link = {
-            'url': MQTT_URL,
+            'url': MQP_URL,
             'type': 'MQTT',
             'name': identifier,
             'description': identifier,
@@ -88,7 +88,7 @@ class DiscoveryMetadata(BaseMetadata):
 
         LOGGER.debug('Adding canonical link')
         canonical_link = {
-            'url': f"{API_URL}/collections/discovery-metadata/{identifier}",
+            'url': f"{API_URL}/collections/discovery-metadata/items/{identifier}",
             'type': 'OARec',
             'name': identifier,
             'description': identifier,

--- a/wis2box/metadata/discovery.py
+++ b/wis2box/metadata/discovery.py
@@ -88,7 +88,7 @@ class DiscoveryMetadata(BaseMetadata):
 
         LOGGER.debug('Adding canonical link')
         canonical_link = {
-            'url': f"{API_URL}/collections/discovery-metadata/items/{identifier}",
+            'url': f"{API_URL}/collections/discovery-metadata/items/{identifier}", # noqa
             'type': 'OARec',
             'name': identifier,
             'description': identifier,

--- a/wis2box/metadata/discovery.py
+++ b/wis2box/metadata/discovery.py
@@ -28,7 +28,7 @@ from pygeometa.schemas.ogcapi_records import OGCAPIRecordOutputSchema
 from wis2box import cli_helpers
 from wis2box.api.backend import load_backend
 from wis2box.api.config import load_config
-from wis2box.env import API_URL, MQP_URL
+from wis2box.env import API_URL, MQTT_URL
 from wis2box.metadata.base import BaseMetadata
 
 LOGGER = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class DiscoveryMetadata(BaseMetadata):
         }
 
         mqp_link = {
-            'url': MQP_URL,
+            'url': MQTT_URL,
             'type': 'MQTT',
             'name': identifier,
             'description': identifier,

--- a/wis2box/metadata/discovery.py
+++ b/wis2box/metadata/discovery.py
@@ -28,7 +28,7 @@ from pygeometa.schemas.ogcapi_records import OGCAPIRecordOutputSchema
 from wis2box import cli_helpers
 from wis2box.api.backend import load_backend
 from wis2box.api.config import load_config
-from wis2box.env import API_URL, MQP_URL
+from wis2box.env import API_URL, MQTT_URL
 from wis2box.metadata.base import BaseMetadata
 
 LOGGER = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class DiscoveryMetadata(BaseMetadata):
 
         LOGGER.debug('Adding distribution links')
         oafeat_link = {
-            'url': f"{API_URL}/collections/{identifier}",
+            'url': f"{API_URL}/collections/items/{identifier}",
             'type': 'OAFeat',
             'name': identifier,
             'description': identifier,
@@ -61,7 +61,7 @@ class DiscoveryMetadata(BaseMetadata):
         }
 
         mqp_link = {
-            'url': MQP_URL,
+            'url': MQTT_URL,
             'type': 'MQTT',
             'name': identifier,
             'description': identifier,


### PR DESCRIPTION
- Add `items/` to fix oafeat link
- Use public MQTT URL instead of URL derived from broker in docker system.
