### PR TITLE
Small fixes

### DIFF
--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -3,7 +3,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Create and publish image to GitHub Container Registry
+name: publish image to ghcr.io
 
 on:
   push:
@@ -14,7 +14,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: wis2box
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
   # Push image to GitHub Packages.
@@ -35,7 +35,7 @@ jobs:
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -43,20 +43,15 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Rename image for publication
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "main" ] && VERSION=latest
-          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
-          echo VERSION=$VERSION >> $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
 
       - name: Build and push
         uses: docker/build-push-action@v2.7.0
@@ -67,5 +62,5 @@ jobs:
           cache-to: type=gha,mode=max
           platforms: linux/arm64, linux/amd64
           push: true
-          tags: |
-            ${{ env.IMAGE_ID }}:${{ env.VERSION }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/ghcr.yml
+++ b/.github/workflows/ghcr.yml
@@ -9,10 +9,12 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: wis2box 
+  IMAGE_NAME: wis2box
 
 jobs:
   # Push image to GitHub Packages.
@@ -24,14 +26,22 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout branch
+        uses: actions/checkout@v2
 
-      - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME --label "runnumber=${GITHUB_RUN_ID}"
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
 
-      - name: Log in to registry
-        # This is where you will update the PAT to GHCR_BUILD_TOKEN
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
 
       - name: Rename image for publication
         run: |
@@ -45,10 +55,17 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           # Use Docker `latest` tag convention
           [ "$VERSION" == "main" ] && VERSION=latest
-          echo IMAGE_ID=$IMAGE_ID
-          echo VERSION=$VERSION
-          echo FULLCONTAINERNAME=$IMAGE_ID:$VERSION >> $GITHUB_ENV
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          echo IMAGE_ID=$IMAGE_ID >> $GITHUB_ENV
+          echo VERSION=$VERSION >> $GITHUB_ENV
 
-      - name: Push to CR
-        run: docker push ${{ env.FULLCONTAINERNAME }}
+      - name: Build and push
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: ./
+          file: ./Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/arm64, linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_ID }}:${{ env.VERSION }}

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -29,6 +29,7 @@ jobs:
     - name: build wis2box
       run: |
         python3 wis2box-ctl.py build
+        python3 wis2box-ctl.py update
     - name: start containers ⚙️
       run: |
         python3 wis2box-ctl.py start
@@ -41,8 +42,8 @@ jobs:
           && wis2box environment show \
           && wis2box data setup -th data.core.observations-surface-land.mw.FWCL.landFixed \
           && wis2box data info -th data.core.observations-surface-land.mw.FWCL.landFixed \
-          && wis2box metadata discovery publish /data/wis2box/metadata/discovery/surface-weather-observations.yml \
           && wis2box metadata station cache /data/wis2box/metadata/station/station_list.csv \
+          && wis2box metadata discovery publish /data/wis2box/metadata/discovery/surface-weather-observations.yml \
           && wis2box metadata station publish-collection \
           && wis2box api add-collection -th data.core.observations-surface-land.mw.FWCL.landFixed /data/wis2box/metadata/discovery/surface-weather-observations.yml \
           && wis2box data ingest -th data.core.observations-surface-land.mw.FWCL.landFixed -p /data/wis2box/observations \

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         pip3 install -r requirements-dev.txt
         python3 setup.py install
-    - name: running on 📦
+    - name: software running on 📦
       run: |
         docker version
         docker-compose version
@@ -38,7 +38,6 @@ jobs:
     - name: start containers ⚙️
       run: |
         python3 wis2box-ctl.py start
-        sleep 15
         python3 wis2box-ctl.py status -a
     - name: test wis2box data ingest/process/publish workflow ⚙️
       run: |

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -18,6 +18,11 @@ jobs:
       run: |
         pip3 install -r requirements-dev.txt
         python3 setup.py install
+    - name: running on 📦
+      run: |
+        docker version
+        docker-compose version
+        python3 -V
     - name: run unit tests ⚙️
       run: |
         pytest tests/unit
@@ -42,8 +47,8 @@ jobs:
           && wis2box environment show \
           && wis2box data setup -th data.core.observations-surface-land.mw.FWCL.landFixed \
           && wis2box data info -th data.core.observations-surface-land.mw.FWCL.landFixed \
-          && wis2box metadata station cache /data/wis2box/metadata/station/station_list.csv \
           && wis2box metadata discovery publish /data/wis2box/metadata/discovery/surface-weather-observations.yml \
+          && wis2box metadata station cache /data/wis2box/metadata/station/station_list.csv \
           && wis2box metadata station publish-collection \
           && wis2box api add-collection -th data.core.observations-surface-land.mw.FWCL.landFixed /data/wis2box/metadata/discovery/surface-weather-observations.yml \
           && wis2box data ingest -th data.core.observations-surface-land.mw.FWCL.landFixed -p /data/wis2box/observations \

--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -21,7 +21,7 @@ jobs:
     - name: software running on 📦
       run: |
         docker version
-        docker-compose version
+        docker compose version
         python3 -V
     - name: run unit tests ⚙️
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apt-get update -y \
     && apt-get install -y ${BUILD_PACKAGES} \
     && apt-get install -y ${DEBIAN_PACKAGES} \
     # install wis2box dependencies
-    && pip3 install https://github.com/wmo-im/csv2bufr/archive/dev.zip \
+    && pip3 install https://github.com/wmo-im/csv2bufr/archive/main.zip \
     && pip3 install https://github.com/geopython/pygeometa/archive/master.zip \
     && pip3 install metpx-sr3 \
     # install wis2box

--- a/docker/auth/Dockerfile
+++ b/docker/auth/Dockerfile
@@ -19,7 +19,7 @@
 #
 ###############################################################################
 
-FROM wis2box_project_wis2box
+FROM ghcr.io/wmo-im/wis2box:latest
 
 RUN apt-get update -y \
     && apt-get install -y gunicorn python3-pip python3-gevent python3-flask python3-flask-cors \

--- a/docker/docker-compose.monitoring.yml
+++ b/docker/docker-compose.monitoring.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 # define virtual network to give fixed IP for loki used by the logging-driver for all containers
 networks:
   vpcbr: # virtual network name
@@ -38,7 +36,7 @@ services:
     env_file:
       - default.env
       - ../dev.env
-    build: 
+    build:
       context: ./mqtt_metrics_collector
     depends_on:
       - mosquitto
@@ -51,7 +49,7 @@ services:
     env_file:
       - default.env
       - ../dev.env
-    build: 
+    build:
       context: ./metrics_collector
     volumes:
       - ${WIS2BOX_HOST_DATADIR}/data/public:/data/wis2box/data/public:ro

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   web-proxy:
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,7 +30,8 @@ services:
       - default.env
       - ../dev.env
     depends_on:
-      - elasticsearch
+      elasticsearch:
+        condition: service_healthy
     volumes:
       - ${WIS2BOX_HOST_DATADIR}:/data/wis2box:ro
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - ../dev.env
     depends_on:
       - elasticsearch
-      - wis2box
     volumes:
       - ${WIS2BOX_HOST_DATADIR}:/data/wis2box:ro
 
@@ -145,6 +144,7 @@ services:
       - ./wis2box/wis2box.cron:/etc/cron.d/wis2box:ro
     depends_on:
       - mosquitto
+      - wis2box-api
 
   wis2box-auth:
     container_name: wis2box-auth

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -30,6 +30,8 @@ services:
     depends_on:
       elasticsearch:
         condition: service_healthy
+      wis2box:
+        condition: service_started
     volumes:
       - ${WIS2BOX_HOST_DATADIR}:/data/wis2box:ro
 
@@ -143,7 +145,6 @@ services:
       - ./wis2box/wis2box.cron:/etc/cron.d/wis2box:ro
     depends_on:
       - mosquitto
-      - wis2box-api
 
   wis2box-auth:
     container_name: wis2box-auth

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   web-proxy:
     container_name: nginx

--- a/docker/docker-compose.yml.promtail
+++ b/docker/docker-compose.yml.promtail
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   # promtail for scraping logs
   promtail:
@@ -52,7 +50,7 @@ services:
       - GF_ALERTING_ENABLED=false
     ports:
       - 3000:3000
-  
+
   web-proxy:
     container_name: nginx
     image: nginx:alpine

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -3,21 +3,46 @@
 Installation
 ============
 
-wis2box is built for easy installation across various operating systems and environments.
+wis2box leverages `Docker`_ for easy installation across operating systems and environments.
 
 Requirements and dependencies
 -----------------------------
 
-wis2box requires `Python`_ 3 and `Docker`_ 1.13+.
+Dependencies are installed as containers in the deployment of wis2box. This
+is true for the wis2box software itself, which runs as a container orchestrating the necessary
+data management workflows of a node in the WIS 2.0 network.
 
-Core dependencies are installed as containers in the Docker Compose deployment of wis2box. This
-is true for the software wis2box itself, which runs as a container orchestrating the necessary
-data management workflows of a node as part of the WIS 2.0 network.
+wis2box runs on `Python`_ 3.8, `Docker Engine`_ 20.10.14, and `Docker Compose`_ 2.4.1.
+If these are already installed, you can skip to installing wis2box.
 
-Once Python and Docker are installed, wis2box needs to be installed.
+    - To install Python, follow `Python installation`_.
+    - To install Docker, follow `Docker Engine installation`_.
+    - To install Docker Compose, follow `Compose installation`_.
+
+Successful installation can be confirmed by inspecting the versions on your system.
+
+.. code-block:: bash
+
+    docker version
+    docker compose version
+    python3 -V
+
+.. note::
+
+    Docker may require post-install configuration. Linux users may need to follow `post install`_
+    steps to grant docker privileges. Users in corporate settings my need to configure
+    Docker's `HTTP/HTTPS proxy`_.
+
+
+Installing wis2box
+------------------
+
+Once Python and Docker are installed, the wis2box software needs to be installed.
 
 ZIP Archive
------------
+^^^^^^^^^^^
+
+wis2box can be installed from a ZIP archive of a the latest branch or a `wis2box release`_.
 
 .. code-block:: bash
 
@@ -26,7 +51,9 @@ ZIP Archive
     cd wis2box-main
 
 GitHub
-------
+^^^^^^
+
+wis2box can also be installed using the git CLI.
 
 .. code-block:: bash
 
@@ -42,5 +69,14 @@ Congratulations! Whichever of the abovementioned methods you chose, you have suc
 onto your system. From here, you can get started with test data by following the :ref:`quickstart`, or continue on to
 :ref:`configuration`.
 
-.. _`Python`: https://www.python.org/downloads
-.. _`Docker`: https://docs.docker.com/get-docker
+
+.. _`Docker`: https://docs.docker.com/get-started/overview/
+.. _`Docker Compose`: https://github.com/docker/compose/releases
+.. _`Compose installation`: https://docs.docker.com/compose/install/
+.. _`Docker Engine`: https://docs.docker.com/engine/release-notes/
+.. _`Docker Engine installation`: https://docs.docker.com/engine/install/
+.. _`HTTP/HTTPS proxy`: https://docs.docker.com/config/daemon/systemd/#httphttps-proxy
+.. _`post install`: https://docs.docker.com/engine/install/linux-postinstall/
+.. _`Python`: https://www.python.org/downloads/release/python-380/
+.. _`Python installation`: https://www.python.org/downloads
+.. _`wis2box release`: https://github.com/wmo-im/wis2box/releases

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -12,12 +12,21 @@ Dependencies are installed as containers in the deployment of wis2box. This
 is true for the wis2box software itself, which runs as a container orchestrating the necessary
 data management workflows of a node in the WIS 2.0 network.
 
-wis2box runs on `Python`_ 3.8, `Docker Engine`_ 20.10.14, and `Docker Compose`_ 2.4.1.
+wis2box requires the following prior to installation:
+
+.. csv-table::
+   :header: Requirement,Version
+   :align: left
+
+   `Python`_,3.8
+   `Docker Engine`_, 20.10.14
+   `Docker Compose`_,2.4.1
+
 If these are already installed, you can skip to installing wis2box.
 
-    - To install Python, follow `Python installation`_.
-    - To install Docker, follow `Docker Engine installation`_.
-    - To install Docker Compose, follow `Compose installation`_.
+- To install Python, follow `Python installation`_.
+- To install Docker, follow `Docker Engine installation`_.
+- To install Docker Compose, follow `Compose installation`_.
 
 Successful installation can be confirmed by inspecting the versions on your system.
 

--- a/docs/source/monitoring/index.rst
+++ b/docs/source/monitoring/index.rst
@@ -12,7 +12,7 @@ Grafana uses two data-sources to display monitoring-data:
 - loki: logging end-point for the docker-containers that compose the wis2box
 
 Prometheus exporters for wis2box
---------------------
+--------------------------------
 
 The exporters for wis2box are based on the `Prometheus Python Client <https://github.com/prometheus/client_python>`_
 

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -140,32 +140,32 @@ def make(args) -> None:
     container = "wis2box" if not args.args else ' '.join(args.args)
 
     if args.command == "config":
-        run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} config'))
+        run(args, split(f'docker compose {DOCKER_COMPOSE_ARGS} config'))
     elif args.command == "build":
         run(args, split(
-            f'docker-compose {DOCKER_COMPOSE_ARGS} build {containers}'))
+            f'docker compose {DOCKER_COMPOSE_ARGS} build {containers}'))
     elif args.command in ["up", "start"]:
         run(args, split(
             'docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions'))
         if containers:
             run(args, split(f"docker start {containers}"))
         else:
-            run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} up -d'))
+            run(args, split(f'docker compose {DOCKER_COMPOSE_ARGS} up -d'))
     elif args.command == "login":
         run(args, split(f'docker exec -it {container} /bin/bash'))
     elif args.command == "login-root":
         run(args, split(f'docker exec -u -0 -it {container} /bin/bash'))
     elif args.command == "logs":
         run(args, split(
-            f'docker-compose {DOCKER_COMPOSE_ARGS} logs --follow {containers}'))
+            f'docker compose {DOCKER_COMPOSE_ARGS} logs --follow {containers}'))
     elif args.command in ["stop", "down"]:
         if containers:
             run(args, split(f"docker stop {containers}"))
         else:
             run(args, split(
-                f'docker-compose {DOCKER_COMPOSE_ARGS} down --remove-orphans {containers}'))
+                f'docker compose {DOCKER_COMPOSE_ARGS} down --remove-orphans {containers}'))
     elif args.command == "update":
-        run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} pull'))
+        run(args, split(f'docker compose {DOCKER_COMPOSE_ARGS} pull'))
     elif args.command == "prune":
         run(args, split('docker container prune -f'))
         run(args, split('docker volume prune -f'))
@@ -177,10 +177,10 @@ def make(args) -> None:
         run(args, split(f'docker rm {_}'))
     elif args.command == "restart":
         run(args, split(
-            f'docker-compose {DOCKER_COMPOSE_ARGS} restart {containers}'))
+            f'docker compose {DOCKER_COMPOSE_ARGS} restart {containers}'))
     elif args.command == "status":
         run(args, split(
-            f'docker-compose {DOCKER_COMPOSE_ARGS} ps {containers}'))
+            f'docker compose {DOCKER_COMPOSE_ARGS} ps {containers}'))
     elif args.command == "lint":
         files = walk_path(".")
         run(args, ('python3', '-m', 'flake8', *files))

--- a/wis2box/data/observations.py
+++ b/wis2box/data/observations.py
@@ -49,7 +49,7 @@ class ObservationData(BaseAbstractData):
         self.mappings = {}
         self.output_data = {}
 
-        mapping_bufr4 = Path(MAPPINGS) / 'synop_bufr.json'
+        mapping_bufr4 = Path(MAPPINGS) / 'malawi_synop_bufr.json'
         mapping_geojson = Path(MAPPINGS) / 'wmo_om_rc0.geojson'
 
         with mapping_bufr4.open() as fh1, mapping_geojson.open() as fh2:


### PR DESCRIPTION
- Update workflow for  publication to ghcr.io. Use `docker/metadata-action` to create tags. Publish on release as well as commits to main.
- Update test workflow. Build and pull all containers during the build step instead of pulling on start. Cache stations before publishing discovery metadata.
- Use ghcr version of wis2box for wis2box-auth.
- wis2box depends on wis2box-api container.