### PR TITLE
Throw more graceful errors during quickstart

### DIFF
--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -6,6 +6,8 @@ jobs:
   main:
     strategy:
       fail-fast: false
+      matrix:
+        ingest: [cli, event]
     runs-on: ubuntu-latest
 
     steps:
@@ -39,7 +41,7 @@ jobs:
       run: |
         python3 wis2box-ctl.py start
         python3 wis2box-ctl.py status -a
-    - name: test wis2box data ingest/process/publish workflow ⚙️
+    - name: Setup wis2box collections ⚙️
       run: |
         docker exec wis2box sh -c " \
           wis2box environment create \
@@ -49,11 +51,20 @@ jobs:
           && wis2box metadata discovery publish /data/wis2box/metadata/discovery/surface-weather-observations.yml \
           && wis2box metadata station cache /data/wis2box/metadata/station/station_list.csv \
           && wis2box metadata station publish-collection \
-          && wis2box api add-collection -th data.core.observations-surface-land.mw.FWCL.landFixed /data/wis2box/metadata/discovery/surface-weather-observations.yml \
-          && cp /data/wis2box/observations/* /data/wis2box/data/incoming/data/core/observations-surface-land/mw/FWCL/landFixed"
+          && wis2box api add-collection -th data.core.observations-surface-land.mw.FWCL.landFixed /data/wis2box/metadata/discovery/surface-weather-observations.yml"
+    - name: Ingest & publish data from CLI
+      if: ${{ matrix.ingest == 'cli' }}
+      run: |
+        docker exec wis2box sh -c " \
+          wis2box data ingest -th data.core.observations-surface-land.mw.FWCL.landFixed -p /data/wis2box/observations"
+    - name: Ingest & publish data with event workflow
+      if: ${{ matrix.ingest == 'event' }}
+      run: |
+        docker exec wis2box sh -c " \
+          cp /data/wis2box/observations/* /data/wis2box/data/incoming/data/core/observations-surface-land/mw/FWCL/landFixed"
     - name: run integration tests ⚙️
       run: |
-        sleep 20
+        sleep 25
         pytest -s tests/integration
     - name: run flake8 ⚙️
       run: |

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -53,18 +53,25 @@ Publish station collection and discovery metadata to the API:
 
 .. code-block:: bash
 
+    wis2box metadata discovery publish $WIS2BOX_DATADIR/metadata/discovery/surface-weather-observations.yml
     wis2box metadata station cache $WIS2BOX_DATADIR/metadata/station/station_list.csv
     wis2box metadata station publish-collection
-    wis2box metadata discovery publish $WIS2BOX_DATADIR/metadata/discovery/surface-weather-observations.yml
 
-
-Process data via CLI:
+Ingest and publish data via command-line interface (CLI) or an MQTT event driven workflow:
 
 .. code-block:: bash
 
-    wis2box data ingest --topic-hierarchy data.core.observations-surface-land.mw.FWCL.landFixed --path $WIS2BOX_DATADIR/observations/WIGOS_0-454-2-AWSNAMITAMBO_2021-07-07.csv
-    wis2box api add-collection-items --recursive --path $WIS2BOX_DATADIR/data/public
+    # CLI
+    wis2box data ingest --topic-hierarchy data.core.observations-surface-land.mw.FWCL.landFixed --path $WIS2BOX_DATADIR/observations
+    # OR
+    # Event driven
+    cp $WIS2BOX_DATADIR/observations/* $WIS2BOX_DATADIR/data/incoming/data/core/observations-surface-land/mw/FWCL/landFixed
 
+Re-publish the stations collection to additionally include link relations to collections with observations published from that station:
+
+.. code-block:: bash
+
+    wis2box metadata station publish-collection
 
 Logout of wis2box container:
 

--- a/wis2box/metadata/station.py
+++ b/wis2box/metadata/station.py
@@ -102,7 +102,7 @@ def check_station_datasets(datasets: list, wigos_id: str) -> Iterator[dict]:
             obs = oaf.collection_items(
                 topic['title'], wigos_station_identifier=wigos_id)
         except RuntimeError as err:
-            LOGGER.warning(f'Warning in topic {topic["title"]}: {err}')
+            LOGGER.warning(f'Warning from topic {topic["title"]}: {err}')
             continue
 
         if obs['numberMatched'] > 0:

--- a/wis2box/metadata/station.py
+++ b/wis2box/metadata/station.py
@@ -95,7 +95,7 @@ def check_station_datasets(datasets: list, wigos_id: str) -> Iterator[dict]:
     oaf = Features(DOCKER_API_URL)
 
     for topic in datasets:
-        if topic == {}:
+        if not topic:
             continue
 
         try:


### PR DESCRIPTION
- Update test workflow to run against both CLI and pure event workflow.
- Update quickstart documentation.
- Throw more graceful warnings when publishing stations with incomplete collections. 