### PR TITLE
Add `wis2box-ctl.py execute` command 

### DIFF
--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -40,45 +40,39 @@ jobs:
         docker logs wis2box
     - name: setup wis2box ⚙️
       run: |
-        docker exec wis2box sh -c " \
-          wis2box environment create \
-          && wis2box environment show \
-          && wis2box api setup"
+        python3 wis2box-ctl.py execute wis2box environment create
+        python3 wis2box-ctl.py execute wis2box environment show
     - name: add Malawi data 🇲🇼
       env:
         TOPIC_HIERARCHY: data.core.observations-surface-land.mw.FWCL.landFixed
         DISCOVERY_METADATA: /data/wis2box/metadata/discovery/mw-surface-weather-observations.yml
         TEST_DATA: /data/wis2box/observations/malawi
       run: |
-        docker exec wis2box sh -c " \
-          wis2box metadata discovery publish $DISCOVERY_METADATA \
-          && wis2box api add-collection -th $TOPIC_HIERARCHY $DISCOVERY_METADATA \
-          && wis2box data ingest -th $TOPIC_HIERARCHY -p $TEST_DATA"
+        python3 wis2box-ctl.py execute wis2box metadata discovery publish $DISCOVERY_METADATA
+        python3 wis2box-ctl.py execute wis2box api add-collection -th $TOPIC_HIERARCHY $DISCOVERY_METADATA
+        python3 wis2box-ctl.py execute wis2box data ingest -th $TOPIC_HIERARCHY -p $TEST_DATA
     - name: add Italy data 🇮🇹
       env:
         TOPIC_HIERARCHY: data.core.observations-surface-land.it.LIIB.landFixed
         DISCOVERY_METADATA: /data/wis2box/metadata/discovery/it-surface-weather-observations.yml
         TEST_DATA: /data/wis2box/observations/italy
       run: |
-        docker exec wis2box sh -c " \
-          wis2box metadata discovery publish $DISCOVERY_METADATA \
-          && wis2box api add-collection -th $TOPIC_HIERARCHY $DISCOVERY_METADATA \
-          && wis2box data ingest -th $TOPIC_HIERARCHY -p $TEST_DATA"
+        python3 wis2box-ctl.py execute wis2box metadata discovery publish $DISCOVERY_METADATA
+        python3 wis2box-ctl.py execute wis2box api add-collection -th $TOPIC_HIERARCHY $DISCOVERY_METADATA
+        python3 wis2box-ctl.py execute wis2box data ingest -th $TOPIC_HIERARCHY -p $TEST_DATA
     - name: add Algeria data 🇩🇿
       env:
         TOPIC_HIERARCHY: data.core.observations-surface-land.dz.DAMM.landFixed
         DISCOVERY_METADATA: /data/wis2box/metadata/discovery/dz-surface-weather-observations.yml
         TEST_DATA: /data/wis2box/observations/algeria
       run: |
-        docker exec wis2box sh -c " \
-          wis2box metadata discovery publish $DISCOVERY_METADATA \
-          && wis2box api add-collection -th $TOPIC_HIERARCHY $DISCOVERY_METADATA \
-          && wis2box data ingest -th $TOPIC_HIERARCHY -p $TEST_DATA"
+        python3 wis2box-ctl.py execute wis2box metadata discovery publish $DISCOVERY_METADATA
+        python3 wis2box-ctl.py execute wis2box api add-collection -th $TOPIC_HIERARCHY $DISCOVERY_METADATA
+        python3 wis2box-ctl.py execute wis2box data ingest -th $TOPIC_HIERARCHY -p $TEST_DATA
     - name: sync stations 🔄
       run: |
         sleep 30
-        docker exec wis2box sh -c ' \
-          wis2box metadata station sync /data/wis2box/metadata/station/station_list.csv'
+        python3 wis2box-ctl.py execute wis2box metadata station sync /data/wis2box/metadata/station/station_list.csv
     - name: run integration tests ⚙️
       run: |
         sleep 5

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -46,6 +46,7 @@ commands = [
     'build',
     'config',
     'down',
+    'execute',
     'lint',
     'logs',
     'login',
@@ -156,6 +157,8 @@ def make(args) -> None:
                 run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} --file docker/docker-compose.dev.yml up'))
             else:
                 run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} up -d'))
+    elif args.command == "execute":
+        run(args, ['docker', 'exec', '-i', 'wis2box', 'sh', '-c', containers])
     elif args.command == "login":
         run(args, split(f'docker exec -it {container} /bin/bash'))
     elif args.command == "login-root":

--- a/wis2box/api/__init__.py
+++ b/wis2box/api/__init__.py
@@ -107,8 +107,7 @@ def setup(ctx, verbosity):
 @click.pass_context
 @cli_helpers.OPTION_TOPIC_HIERARCHY
 @cli_helpers.OPTION_PATH
-@click.option('--recursive', '-r', is_flag=True, default=False,
-              help='Process directory recursively')
+@cli_helpers.OPTION_RECURSIVE
 @cli_helpers.OPTION_VERBOSITY
 def add_collection_items(ctx, topic_hierarchy, path, recursive, verbosity):
     """Add collection items to API backend"""

--- a/wis2box/cli_helpers.py
+++ b/wis2box/cli_helpers.py
@@ -37,6 +37,10 @@ OPTION_PATH = click.option('--path', '-p', required=True,
 OPTION_TOPIC_HIERARCHY = click.option('--topic-hierarchy', '-th',
                                       help='Topic hierarchy')
 
+OPTION_RECURSIVE = click.option('--recursive', '-r', default=False,
+                                is_flag=True,
+                                help='Process directory recursively')
+
 
 def OPTION_VERBOSITY(f):
     logging_options = ['ERROR', 'WARNING', 'INFO', 'DEBUG']

--- a/wis2box/data/__init__.py
+++ b/wis2box/data/__init__.py
@@ -133,8 +133,7 @@ def clean(ctx, days, verbosity):
 @click.pass_context
 @cli_helpers.OPTION_TOPIC_HIERARCHY
 @cli_helpers.OPTION_PATH
-@click.option('--recursive', '-r', is_flag=True, default=False,
-              help='Process directory recursively')
+@cli_helpers.OPTION_RECURSIVE
 @cli_helpers.OPTION_VERBOSITY
 def ingest(ctx, topic_hierarchy, path, recursive, verbosity):
     """Ingest data file or directory"""


### PR DESCRIPTION
- Add execute command to wis2box-ctl to run shell-like commands in the wis2box container without logging in to the container.
- Move recursive CLI option to cli_helpers.py