### PR TITLE
fix station cache for empty tsi

### DIFF
--- a/wis2box/metadata/station.py
+++ b/wis2box/metadata/station.py
@@ -227,7 +227,7 @@ def get_valid_wsi(wsi: str = '', tsi: str = '') -> str:
         reader = csv.DictReader(fh)
         for row in reader:
             if wsi == row['wigos_station_identifier'] or \
-               tsi == row['traditional_station_identifier']:
+               (tsi == row['traditional_station_identifier'] and tsi != ''):
                 return row['wigos_station_identifier']
 
 


### PR DESCRIPTION
I noted that caching my stations was working incorrectly when my list contained multiple tsi with empty strings. This is a hot-fix to address this issue.