### PR TITLE
fix wis2box cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,10 @@ RUN cd /app \
 
 WORKDIR /home/wis2box
 
+# add wis2box.cron to crontab
+COPY ./docker/wis2box/wis2box.cron /etc/cron.d/wis2box.cron
+RUN cat /etc/cron.d/wis2box.cron > /etc/crontab && crontab /etc/crontab
+
 COPY ./docker/entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -96,7 +96,6 @@ services:
       - ../dev.env
     volumes:
       - ${WIS2BOX_HOST_DATADIR}:/data/wis2box:rw
-      - ./wis2box/wis2box.cron:/etc/cron.d/wis2box:ro
     depends_on:
       minio:
         condition: service_healthy

--- a/docker/wis2box/wis2box.cron
+++ b/docker/wis2box/wis2box.cron
@@ -1,3 +1,3 @@
 0 0 * * * wis2box data clean --days=$WIS2BOX_DATA_RETENTION_DAYS > /proc/1/fd/1 2>/proc/1/fd/2
 0 1 * * * wis2box data archive > /proc/1/fd/1 2>/proc/1/fd/2
-* * * * * echo "wis2box.cron is alive" > /proc/1/fd/1 2>/proc/1/fd/2
+*/10 * * * * echo "wis2box.cron is alive" > /proc/1/fd/1 2>/proc/1/fd/2

--- a/docker/wis2box/wis2box.cron
+++ b/docker/wis2box/wis2box.cron
@@ -1,5 +1,3 @@
-# Clean out files older than WIS2BOX_DATA_RETENTION_DAYS daily at 0Z
-0 0 * * * wis2box data clean --days=$WIS2BOX_DATA_RETENTION_DAYS
-
-# Archive data daily at 1Z
-0 1 * * * wis2box data archive
+0 0 * * * wis2box data clean --days=$WIS2BOX_DATA_RETENTION_DAYS > /proc/1/fd/1 2>/proc/1/fd/2
+0 1 * * * wis2box data archive > /proc/1/fd/1 2>/proc/1/fd/2
+* * * * * echo "wis2box.cron is alive" > /proc/1/fd/1 2>/proc/1/fd/2


### PR DESCRIPTION
a fix for https://github.com/wmo-im/wis2box/issues/240

I added a third cronjob that prints a mesage to indicate the cron-service is alive

stdout and stderr logs for cronjobs are redirected to /proc/1/fd/1-2  to ensure they end up in the docker logs