### PR TITLE
Bufr tables latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,11 +33,14 @@ RUN if [ "$WIS2BOX_PIP3_EXTRA_PACKAGES" = "None" ]; \
     else export WIS2BOX_PIP3_EXTRA_PACKAGES=pip3 install ${WIS2BOX_PIP3_EXTRA_PACKAGES}; \
     fi
 
+# We need latest version of BUFR tables, these are only available in bookworm release, add to sources
+RUN echo 'deb http://deb.debian.org/debian bookworm main' >> /etc/apt/sources.list
+
 # install dependencies
-# FIXME: install newer version of eccodes
 # FIXME: csv2bufr/bufr2geojson: remove and install from requirements.txt once we have a stable release
 # FIXME: pygeometa: remove and install from requirements.txt once we have a stable release
 RUN apt-get update -y \
+    && apt-get install -y -t bookworm libeccodes-data \
     && apt-get install -y ${DEBIAN_PACKAGES} \
     # install wis2box dependencies
     && pip3 install --no-cache-dir https://github.com/wmo-im/csv2bufr/archive/refs/tags/v0.2.0.zip \

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -151,7 +151,7 @@ def make(args) -> None:
         run(args, split(
             'docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions'))
         if containers:
-            run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} up -d {containers}'))
+            run(args, split(f"docker start {containers}"))
         else:
             if args.command == 'start-dev':
                 run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} --file docker/docker-compose.dev.yml up'))
@@ -184,7 +184,6 @@ def make(args) -> None:
         _ = run(args, split('docker ps -a -q'), asciiPipe=True)
         run(args, split(f'docker rm {_}'))
     elif args.command == "restart":
-        print(f"Restarting {containers}")
         run(args, split(
             f'docker-compose {DOCKER_COMPOSE_ARGS} restart {containers}'))
     elif args.command == "status":

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -151,7 +151,7 @@ def make(args) -> None:
         run(args, split(
             'docker plugin install grafana/loki-docker-driver:latest --alias loki --grant-all-permissions'))
         if containers:
-            run(args, split(f"docker start {containers}"))
+            run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} up -d {containers}'))
         else:
             if args.command == 'start-dev':
                 run(args, split(f'docker-compose {DOCKER_COMPOSE_ARGS} --file docker/docker-compose.dev.yml up'))
@@ -184,6 +184,7 @@ def make(args) -> None:
         _ = run(args, split('docker ps -a -q'), asciiPipe=True)
         run(args, split(f'docker rm {_}'))
     elif args.command == "restart":
+        print(f"Restarting {containers}")
         run(args, split(
             f'docker-compose {DOCKER_COMPOSE_ARGS} restart {containers}'))
     elif args.command == "status":


### PR DESCRIPTION
Docker file updated to add Debian bookworm to source list and to then install the latest version of the ecCodes BUFR tables from bookworm. The tables are not available as part of bullseye.