### PR TITLE
add client id to pubsub broker client

### DIFF
--- a/wis2box/data/base.py
+++ b/wis2box/data/base.py
@@ -128,7 +128,8 @@ class BaseAbstractData:
         # load plugin for broker
         defs = {
             'codepath': PLUGINS['pubsub']['mqtt']['plugin'],
-            'url': BROKER_PUBLIC
+            'url': BROKER_PUBLIC,
+            'client_type': 'publisher'
         }
         broker = load_plugin('pubsub', defs)
         topic = f'origin/a/wis2/{self.topic_hierarchy.dirpath}'

--- a/wis2box/plugin.py
+++ b/wis2box/plugin.py
@@ -66,7 +66,6 @@ def load_plugin(plugin_type: PluginTypes, defs: dict) -> Any:
 
     :param plugin_type: type of plugin (`data`)
     :param defs: `def` dict of plugin initializers
-                 (topic_hierarchy, codepath)
 
     :returns: plugin object
     """

--- a/wis2box/pubsub/mqtt.py
+++ b/wis2box/pubsub/mqtt.py
@@ -44,8 +44,8 @@ class MQTTPubSubClient(BasePubSubClient):
         super().__init__(broker)
         self.type = 'mqtt'
         self._port = self.broker_url.port
+        self.client_id = f"wis2box-mqtt-{self.broker['client_type']}-{random.randint(0, 1000)}"  # noqa
 
-        self.client_id = f'wis2box-mqtt-{random.randint(0, 1000)}'
         msg = f'Connecting to broker {self.broker} with id {self.client_id}'
         LOGGER.debug(msg)
         self.conn = mqtt_client.Client(self.client_id)

--- a/wis2box/pubsub/subscribe.py
+++ b/wis2box/pubsub/subscribe.py
@@ -84,7 +84,8 @@ def subscribe(ctx, broker, topic, verbosity):
 
     defs = {
         'codepath': PLUGINS['pubsub']['mqtt']['plugin'],
-        'url': f'mqtt://{BROKER_USERNAME}:{BROKER_PASSWORD}@{BROKER_HOST}:{BROKER_PORT}'  # noqa
+        'url': f'mqtt://{BROKER_USERNAME}:{BROKER_PASSWORD}@{BROKER_HOST}:{BROKER_PORT}',  # noqa
+        'client_type': 'subscriber'
     }
 
     broker = load_plugin('pubsub', defs)


### PR DESCRIPTION
Adds a `client_type` qualifier to pubsub broker to more clearly identify scope/workflow of a given pubsub client.