### PR TITLE
add restart always and mem-limits

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -35,6 +35,9 @@ services:
   minio:
     container_name: wis2box-minio
     image: minio/minio
+    mem_limit: 512m
+    memswap_limit: 512m
+    restart: always
     env_file:
       - default.env
       - ../dev.env
@@ -62,8 +65,8 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       # - xpack.security.enabled=true  # TODO: setup credentials
-    mem_limit: 1g
-    memswap_limit: 1g
+    mem_limit: 1.5g
+    memswap_limit: 1.5g
     volumes:
       - es-data:/usr/share/elasticsearch/data:rw
     # ulimits:
@@ -89,6 +92,9 @@ services:
 
   wis2box:
     container_name: wis2box
+    mem_limit: 1g
+    memswap_limit: 1g
+    restart: always
     #image: ghcr.io/wmo-im/wis2box:0.4.0
     build:
       context: ..


### PR DESCRIPTION
restart: always,  in combination with memory-limits so container restarts after stop due to memory-limit hit and the stack will remain alive despite memory-leaks 