### PR TITLE
monitoring fix

### DIFF
--- a/docker/grafana/dashboards/home.json
+++ b/docker/grafana/dashboards/home.json
@@ -94,7 +94,7 @@
         "y": 0
       },
       "id": 2,
-      "interval": "5m",
+      "interval": "1m",
       "maxDataPoints": 3000,
       "options": {
         "legend": {
@@ -116,7 +116,7 @@
           "editorMode": "code",
           "exemplar": true,
           "expr": "delta(wis2box_storage_incoming_total{}[$__interval])",
-          "interval": "5m",
+          "interval": "1m",
           "legendFormat": "New/updated files per hour in wis2box-incoming",
           "range": true,
           "refId": "A"
@@ -230,7 +230,7 @@
         "y": 7
       },
       "id": 6,
-      "interval": "5m",
+      "interval": "1m",
       "options": {
         "legend": {
           "calcs": [],
@@ -251,7 +251,7 @@
           "editorMode": "code",
           "exemplar": true,
           "expr": "delta(wis2box_storage_public_total{}[$__interval])",
-          "interval": "5m",
+          "interval": "1m",
           "legendFormat": "New/updated files in wis2box-public",
           "range": true,
           "refId": "A"
@@ -325,7 +325,7 @@
         "y": 14
       },
       "id": 10,
-      "interval": "5m",
+      "interval": "1m",
       "options": {
         "legend": {
           "calcs": [],
@@ -346,7 +346,7 @@
           "editorMode": "code",
           "exemplar": true,
           "expr": "delta(wis2box_notify_total[$__interval])",
-          "interval": "5m",
+          "interval": "1m",
           "legendFormat": "WIS2.0 notifications",
           "range": true,
           "refId": "A"
@@ -364,7 +364,7 @@
     "list": []
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-3h",
     "to": "now"
   },
   "timepicker": {},

--- a/docker/mqtt_metrics_collector/mqtt_metrics_collector.py
+++ b/docker/mqtt_metrics_collector/mqtt_metrics_collector.py
@@ -77,7 +77,7 @@ notify_topic_wsi_total = Counter('wis2box_notify_topic_wsi_total',
                                  'Total notifications sent by wis2box, by topic and WSI', # noqa
                                  ["topic", "WSI"])
 
-failure_total = Counter('wi2box_failure_total',
+failure_total = Counter('wis2box_failure_total',
                         'Total failed actions reported by wis2box')
 failure_descr_wsi_total = Counter('wis2box_failure_detail_total',
                                     'Total failed actions sent by wis2box, by description and WSI', # noqa

--- a/wis2box/handler.py
+++ b/wis2box/handler.py
@@ -59,14 +59,6 @@ class Handler:
             th = self.filepath
             fuzzy = True
 
-        # handler uses local broker to publish success/failure messages
-        defs = {
-            'codepath': PLUGINS['pubsub']['mqtt']['plugin'],
-            'url': f"mqtt://{BROKER_USERNAME}:{BROKER_PASSWORD}@{BROKER_HOST}:{BROKER_PORT}", # noqa
-            'client_type': 'handler-publisher'
-        }
-        self.local_broker = load_plugin('pubsub', defs)
-
         try:
             self.topic_hierarchy, self.plugins = validate_and_load(
                 th, self.filetype, fuzzy=fuzzy)
@@ -86,8 +78,14 @@ class Handler:
         if plugin is not None:
             cl = plugin.__class__
             message['plugin'] = f"{cl.__module__ }.{cl.__name__}"
-        # publish message
-        self.local_broker.pub('wis2box/failure', json.dumps(message))
+        # handler uses local broker to publish success/failure messages
+        defs = {
+            'codepath': PLUGINS['pubsub']['mqtt']['plugin'],
+            'url': f"mqtt://{BROKER_USERNAME}:{BROKER_PASSWORD}@{BROKER_HOST}:{BROKER_PORT}", # noqa
+            'client_type': 'handler-publisher'
+        }
+        local_broker = load_plugin('pubsub', defs)
+        local_broker.pub('wis2box/failure', json.dumps(message))
 
     def handle(self) -> bool:
         for plugin in self.plugins:


### PR DESCRIPTION
I noted that testing with a bufr with multiple messages, in which some stations were ok but other were reporting did not work for my monitoring so I added these fixes. 
Initiate local_broker when publishing message
More granular timing in grafana dashboard