### PR TITLE
fix to display errors wis2box-management container

### DIFF
--- a/grafana/dashboards/home.json
+++ b/grafana/dashboards/home.json
@@ -155,7 +155,7 @@
             "uid": "wis2box-loki"
           },
           "editorMode": "builder",
-          "expr": "{compose_service=\"wis2box\"} |~ `ERROR`",
+          "expr": "{compose_service=\"wis2box-management\"} |~ `ERROR`",
           "hide": false,
           "legendFormat": "",
           "queryType": "range",


### PR DESCRIPTION
PR 362 renamed the wis2box-container to wis2box-management, update the dashboard to grep errors using the new container name