### PR TITLE
pin minio release image: 2022-12-02T19-19-22Z.fips

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   minio:
     container_name: wis2box-minio
-    image: minio/minio
+    image: minio/minio:RELEASE.2022-12-02T19-19-22Z.fips
     mem_limit: 512m
     memswap_limit: 512m
     restart: always


### PR DESCRIPTION
The minio-interface keeps changing recently due to wis2box pulling in the latest version of minio, which makes the documentation screenshots inconsistent (and I dislike the new login-window with ads for commercial versions...)
I would recommend we fix minio to this release. 