### PR TITLE
update WNM generation (#391)

### DIFF
--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -17,7 +17,10 @@ jobs:
       run: |
         pip3 install -r requirements-dev.txt
         python3 setup.py install
-    - name: software running on 📦
+    - name: cache schemas 📦
+      run: |
+        pywis-pubsub schema sync
+    - name: display Docker and Python versions 📦
       run: |
         docker version
         docker-compose version

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -26,6 +26,7 @@
 import csv
 from pathlib import Path
 
+from pywis_pubsub.validation import validate_message
 from requests import Session, codes
 
 DATADIR = Path('.').parent.absolute() / 'tests/data'
@@ -190,13 +191,18 @@ def test_message_api():
     url = f'{API_URL}/collections/messages/items?sortby=wigos_station_identifier'  # noqa
     r = SESSION.get(url).json()
 
-    assert r['numberMatched'] == 197
+    assert r['numberMatched'] == 212
 
     msg = r['features'][0]
+
+    is_valid, _ = validate_message(msg)
+    assert is_valid
+
     assert msg['geometry'] is not None
 
     props = msg['properties']
-    assert props['wigos_station_identifier'] == '0-12-0-08BECCN60577'
+    assert props['datetime'] == '2023-01-18T00:00:00Z'
+    assert props['wigos_station_identifier'] == '0-20000-0-15015'
     assert props['integrity']['method'] == 'sha512'
     assert props['data_id'].startswith('wis2')
 

--- a/wis2box-management/wis2box/data/base.py
+++ b/wis2box-management/wis2box/data/base.py
@@ -127,6 +127,7 @@ class BaseAbstractData:
         raise NotImplementedError()
 
     def notify(self, identifier: str, storage_path: str,
+               datetime_: str,
                geometry: dict = None,
                wigos_station_identifier: str = None) -> bool:
         """
@@ -134,6 +135,7 @@ class BaseAbstractData:
 
         :param storage_path: path to data on storage
         :param identifier: identifier
+        :param datetime_: `datetime` object of temporal aspect of data
         :param geometry: `dict` of GeoJSON geometry object
         :param wigos_station_identifier: WSI associated with the data
 
@@ -147,7 +149,7 @@ class BaseAbstractData:
         data_id_topic = topic.replace('origin/a/', '')
 
         wis_message = WISNotificationMessage(
-            identifier, data_id_topic, storage_path, geometry,
+            identifier, data_id_topic, storage_path, datetime_, geometry,
             wigos_station_identifier)
 
         # load plugin for public broker
@@ -221,7 +223,14 @@ class BaseAbstractData:
                         wsi = item['_meta'].get('wigos_station_identifier')
 
                     LOGGER.debug('Sending notification to broker')
+
+                    try:
+                        datetime_ = item['_meta']['properties']['datetime']
+                    except KeyError:
+                        datetime_ = item['_meta'].get('data_date')
+
                     self.notify(identifier, storage_path,
+                                datetime_,
                                 item['_meta'].get('geometry'), wsi)
                 else:
                     LOGGER.debug('No notification sent')


### PR DESCRIPTION
Addresses #391 

- updates `id` from string to UUID (WNM [requirement](https://wmo-im.github.io/wis2-notification-message/standard/wis2-notification-message-DRAFT.html#_identifier)).  This change results in an additional 15 messages being generated as part of the integration tests (thanks @webb-ben for catching)
- adds `properties.datetime`, which is currently [required](https://wmo-im.github.io/wis2-notification-message/standard/wis2-notification-message-DRAFT.html#_temporal_description_datetime_start_datetime_end_datetime) in WNM (note: this is currently in [discussion](https://github.com/wmo-im/wis2-notification-message/issues/34) in TT-WISMD to make optional, but it makes sense for wis2box to provide given message generation is close to the data pipeline, and can be easily derived)
- adds WNM validation to CI