### PR TITLE
install from archive uses port 80

### DIFF
--- a/docs/source/reference/administration.rst
+++ b/docs/source/reference/administration.rst
@@ -58,7 +58,7 @@ A default wis2box installation utilizes the following ports for public services:
 Public services
 ^^^^^^^^^^^^^^^
 
-- ``8999``: Web application, API application, storage
+- ``80``: Web application, API application, storage
 - ``1883``: Message broker via MQTT
 - ``8884``: Message broker via MQTT/WebSockets
 

--- a/docs/source/reference/auth.rst
+++ b/docs/source/reference/auth.rst
@@ -43,8 +43,8 @@ easily added to requests using `cURL`_.
 
 .. code-block:: bash
 
-    curl -H "Authorization: Bearer mytoken" "http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop"
-    curl -H "Authorization: Bearer notmytoken" "http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop"
+    curl -H "Authorization: Bearer mytoken" "http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop"
+    curl -H "Authorization: Bearer notmytoken" "http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop"
 
 
 Removing Access Control

--- a/docs/source/reference/configuration.rst
+++ b/docs/source/reference/configuration.rst
@@ -97,7 +97,7 @@ API configurations drive control of the OGC API setup.
 .. code-block:: bash
 
     WIS2BOX_API_TYPE=pygeoapi  # server tpye
-    WIS2BOX_API_URL=http://localhost:8999/pygeoapi  # public landing page endpoint
+    WIS2BOX_API_URL=http://localhost/pygeoapi  # public landing page endpoint
     WIS2BOX_API_BACKEND_TYPE=Elasticsearch  # backend provider type
     WIS2BOX_API_BACKEND_URL=http://elasticsearch:9200  # internal backend connection URL
     WIS2BOX_DOCKER_API_URL=http://wis2box-api:80/oapi  # container name of API container (for internal communications/workflow)
@@ -150,7 +150,7 @@ Additional directives provide various configurationscontrol of configuration opt
 
 .. code-block:: bash
 
-    WIS2BOX_URL=http://localhost:8999/  # public wis2box url
+    WIS2BOX_URL=http://localhost/  # public wis2box url
     WIS2BOX_AUTH_STORE=http://wis2box-auth # wis2box auth service location
 
 

--- a/docs/source/reference/data-access/python-api-owslib.ipynb
+++ b/docs/source/reference/data-access/python-api-owslib.ipynb
@@ -31,7 +31,7 @@
     "    print(json.dumps(input, indent=2))\n",
     "\n",
     "\n",
-    "api = 'http://localhost:8999/oapi'"
+    "api = 'http://localhost/oapi'"
    ]
   },
   {

--- a/docs/source/reference/data-access/python-api-requests.ipynb
+++ b/docs/source/reference/data-access/python-api-requests.ipynb
@@ -31,7 +31,7 @@
     "\n",
     "\n",
     "# define the endpoint of the OGC API\n",
-    "api = 'http://localhost:8999/oapi'"
+    "api = 'http://localhost/oapi'"
    ]
   },
   {
@@ -151,19 +151,19 @@
      "text": [
       "Data access links:\n",
       "\n",
-      "{'rel': 'self', 'type': 'application/geo+json', 'title': 'This document as GeoJSON', 'href': 'http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=json'} http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=json (application/geo+json) self\n",
-      "{'rel': 'alternate', 'type': 'application/ld+json', 'title': 'This document as RDF (JSON-LD)', 'href': 'http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=jsonld'} http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=jsonld (application/ld+json) alternate\n",
-      "{'rel': 'alternate', 'type': 'text/html', 'title': 'This document as HTML', 'href': 'http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=html'} http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=html (text/html) alternate\n",
-      "{'rel': 'collection', 'type': 'application/json', 'title': 'Discovery metadata', 'href': 'http://localhost:8999/oapi/collections/discovery-metadata'} http://localhost:8999/oapi/collections/discovery-metadata (application/json) collection\n"
+      "{'rel': 'self', 'type': 'application/geo+json', 'title': 'This document as GeoJSON', 'href': 'http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=json'} http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=json (application/geo+json) self\n",
+      "{'rel': 'alternate', 'type': 'application/ld+json', 'title': 'This document as RDF (JSON-LD)', 'href': 'http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=jsonld'} http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=jsonld (application/ld+json) alternate\n",
+      "{'rel': 'alternate', 'type': 'text/html', 'title': 'This document as HTML', 'href': 'http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=html'} http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=html (text/html) alternate\n",
+      "{'rel': 'collection', 'type': 'application/json', 'title': 'Discovery metadata', 'href': 'http://localhost/oapi/collections/discovery-metadata'} http://localhost/oapi/collections/discovery-metadata (application/json) collection\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "['http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=json',\n",
-       " 'http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=jsonld',\n",
-       " 'http://localhost:8999/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=html',\n",
-       " 'http://localhost:8999/oapi/collections/discovery-metadata']"
+       "['http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=json',\n",
+       " 'http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=jsonld',\n",
+       " 'http://localhost/oapi/collections/discovery-metadata/items/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop?f=html',\n",
+       " 'http://localhost/oapi/collections/discovery-metadata']"
       ]
      },
      "execution_count": 4,
@@ -201,7 +201,7 @@
     {
      "data": {
       "text/plain": [
-       "'http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop'"
+       "'http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop'"
       ]
      },
      "execution_count": 5,
@@ -210,7 +210,7 @@
     }
    ],
    "source": [
-    "dataset_api_link = 'http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop'\n",
+    "dataset_api_link = 'http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop'\n",
     "\n",
     "dataset_api_link"
    ]

--- a/docs/source/reference/data-access/qgis-api.rst
+++ b/docs/source/reference/data-access/qgis-api.rst
@@ -28,7 +28,7 @@ interact with the wis2box discovery catalogue:
 - click the "Services" tab
 - click "New"
 - enter a name for the discovery catalogue endpoint
-- enter the URL to the discovery catalogue endpoint (i.e. ``http://localhost:8999/oapi/collections/discovery-metadata``)
+- enter the URL to the discovery catalogue endpoint (i.e. ``http://localhost/oapi/collections/discovery-metadata``)
 - ensure "Catalogue Type" is set to "OGC API - Records"
 - click "OK"
 
@@ -70,7 +70,7 @@ with the wis2box API:
 - from the QGIS menu, select *Layer -> Add Layer -> Add WFS Layer...*
 - click "New"
 - enter a name for the API endpoint
-- enter the URL to the API endpoint (i.e. ``http://localhost:8999/oapi``)
+- enter the URL to the API endpoint (i.e. ``http://localhost/oapi``)
 - under "WFS Options", set "Version" to "OGC API - Features"
 - click "OK"
 - click "Connect"

--- a/docs/source/reference/data-access/r-api.ipynb
+++ b/docs/source/reference/data-access/r-api.ipynb
@@ -79,7 +79,7 @@
     "library(dplyr)\n",
     "\n",
     "oapi <- \"http://oapi/oapi\" # jupyter is run through docker\n",
-    "#oapi = http://localhost:8999/oapi # jupyter is run on host machine"
+    "#oapi = http://localhost/oapi # jupyter is run on host machine"
    ]
   },
   {

--- a/docs/source/reference/quickstart.rst
+++ b/docs/source/reference/quickstart.rst
@@ -6,6 +6,15 @@ Quickstart with test data
 The 'quickstart' deploys wis2box with test data and provides a vital reference for wis2box developers to validate their contributions do not break the wis2box core functionality.
 It is the minimal runtime configuration profile as used in wis2box GitHub CI/CD: `GitHub Actions`_.
 
+.. note:: wis2box web components are run on port 80 by default.  When using wis2box from source, the default port for web components is 8999, to be used for development.
+
+To download the wis2box from source: 
+
+.. code-block:: bash
+
+   git clone https://github.comn/wmo-in/wis2box.git
+
+
 The test enviroment file is provided in ``tests/test.env``.
 
 To run with the 'quickstart' configuration, copy this file to ``dev.env`` in your working directory:

--- a/docs/source/reference/services.rst
+++ b/docs/source/reference/services.rst
@@ -9,21 +9,21 @@ to users, applications and beyond.
 Discovery Catalogue
 -------------------
 
-The discovery catalogue is powered by `OGC API - Records`_ and is located at http://localhost:8999/oapi/collections/discovery-metadata
+The discovery catalogue is powered by `OGC API - Records`_ and is located at http://localhost/oapi/collections/discovery-metadata
 
-The OGC API endpoint is located by default at http://localhost:8999/oapi.  The discovery catalogue endpoint is located at http://localhost:8999/oapi/collections/discovery-metadata
+The OGC API endpoint is located by default at http://localhost/oapi.  The discovery catalogue endpoint is located at http://localhost/oapi/collections/discovery-metadata
 
 Below are some examples of working with the discovery catalogue.
 
-- description of catalogue: http://localhost:8999/oapi/collections/discovery-metadata
-- catalogue queryables: http://localhost:8999/oapi/collections/discovery-metadata/queryables
+- description of catalogue: http://localhost/oapi/collections/discovery-metadata
+- catalogue queryables: http://localhost/oapi/collections/discovery-metadata/queryables
 - catalogue queries
 
-  - records (browse): http://localhost:8999/oapi/collections/discovery-metadata/items
-  - query by spatial (bounding box): http://localhost:8999/oapi/collections/discovery-metadata/items?bbox=32,-17,36,-8
-  - query by temporal extent (since): http://localhost:8999/oapi/collections/discovery-metadata/items?datetime=2021/..
-  - query by temporal extent (before): http://localhost:8999/oapi/collections/discovery-metadata/items?datetime=../2022
-  - query by freetext: http://localhost:8999/oapi/collections/discovery-metadata/items?q=observations
+  - records (browse): http://localhost/oapi/collections/discovery-metadata/items
+  - query by spatial (bounding box): http://localhost/oapi/collections/discovery-metadata/items?bbox=32,-17,36,-8
+  - query by temporal extent (since): http://localhost/oapi/collections/discovery-metadata/items?datetime=2021/..
+  - query by temporal extent (before): http://localhost/oapi/collections/discovery-metadata/items?datetime=../2022
+  - query by freetext: http://localhost/oapi/collections/discovery-metadata/items?q=observations
 
 .. note::
 
@@ -36,10 +36,10 @@ Below are some examples of working with the discovery catalogue.
 Data API
 --------
 
-wis2box data is made available via `OGC API - Features`_ and is located at http://localhost:8999/oapi
+wis2box data is made available via `OGC API - Features`_ and is located at http://localhost/oapi
 standards.
 
-The OGC API endpoint is located by default at http://localhost:8999/oapi
+The OGC API endpoint is located by default at http://localhost/oapi
 
 Below are some examples of working with the discovery catalogue.
 
@@ -50,16 +50,16 @@ Below are some examples of working with the discovery catalogue.
      collection id accordingly
 
 
-- list of dataset collections: http://localhost:8999/oapi/collections
-- collection description: http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop
-- collection queryables: http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/queryables
-- collection items (browse): http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items
+- list of dataset collections: http://localhost/oapi/collections
+- collection description: http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop
+- collection queryables: http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/queryables
+- collection items (browse): http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items
 - collection queries
 
-  - set limit/offset (paging): http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items?limit=1&startindex=2
-  - query by spatial (bounding box): http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items?bbox=32,-17,36,-8
-  - query by temporal extent (since): http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items?datetime=2021/..
-  - query by temporal extent (before): http://localhost:8999/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items?datetime=../2022
+  - set limit/offset (paging): http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items?limit=1&startindex=2
+  - query by spatial (bounding box): http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items?bbox=32,-17,36,-8
+  - query by temporal extent (since): http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items?datetime=2021/..
+  - query by temporal extent (before): http://localhost/oapi/collections/mwi.mwi_met_centre.data.core.weather.surface-based-observations.synop/items?datetime=../2022
 
 .. note::
 
@@ -72,7 +72,7 @@ Below are some examples of working with the discovery catalogue.
 Management API
 ^^^^^^^^^^^^^^
 
-The Data API also provides a management API to manage resources in alignment with `OGC API - Features - Part 4: Create, Replace, Update and Delete`_, which is available at http://localhost:8999/oapi/admin.
+The Data API also provides a management API to manage resources in alignment with `OGC API - Features - Part 4: Create, Replace, Update and Delete`_, which is available at http://localhost/oapi/admin.
 
 
 SpatioTemporal Asset Catalog (STAC)
@@ -80,7 +80,7 @@ SpatioTemporal Asset Catalog (STAC)
 
 The wis2box `SpatioTemporal Asset Catalog (STAC)`_ endpoint can be found at:
 
-http://localhost:8999/stac
+http://localhost/stac
 
 ...providing the user with a crawlable catalogue of all data on a wis2box.
 
@@ -90,7 +90,7 @@ Web Accessible Folder (WAF)
 
 The wis2box Web Accessible Folder publich bucket endpoint can be found at:
 
-http://localhost:8999/data/
+http://localhost/data/
 
 ...providing the user with a crawlable online folder of all data on a wis2box.
 

--- a/docs/source/user/public-services-setup.rst
+++ b/docs/source/user/public-services-setup.rst
@@ -92,6 +92,11 @@ The internal MQTT broker uses the default username/password of ``wis2box/wis2box
     WIS2BOX_BROKER_PASSWORD=myuniquepassword
     WIS2BOX_BROKER_PUBLIC=mqtt://${WIS2BOX_BROKER_USERNAME}:${WIS2BOX_BROKER_PASSWORD}@mosquitto:1883
 
+    # update minio settings after updating broker defaults
+    MINIO_NOTIFY_MQTT_USERNAME_WIS2BOX=${WIS2BOX_BROKER_USERNAME}
+    MINIO_NOTIFY_MQTT_PASSWORD_WIS2BOX=${WIS2BOX_BROKER_PASSWORD}
+    MINIO_NOTIFY_MQTT_BROKER_WIS2BOX=tcp://${WIS2BOX_BROKER_HOST}:${WIS2BOX_BROKER_PORT}
+
 The internal MQTT broker is accessible on the host ``mosquitto`` within the Docker network used by wis2box.
 
 By default port 1883 of the mosquitto container is mapped to port 1883 of the host running wis2box. 

--- a/docs/source/user/public-services-setup.rst
+++ b/docs/source/user/public-services-setup.rst
@@ -11,8 +11,7 @@ To share your data with the WIS2 network, you need to expose some of your wis2bo
 Nginx (HTTP)
 ^^^^^^^^^^^^
 
-wis2box runs a local nginx container allowing access to the following HTTP based services on port 8999:
-
+wis2box runs a local nginx container allowing access to the following HTTP based services on port 80:
 
 .. csv-table::
    :header: Function, URL
@@ -38,7 +37,7 @@ After updating ``WIS2BOX_URL``, please stop and start your wis2box using ``wis2b
 
 .. note::
 
-   By default the environment variable ``WIS2BOX_URL`` resolves to ``http://localhost:8999``.
+   By default the environment variable ``WIS2BOX_URL`` resolves to ``http://localhost``.
    This URL will define the ``/data`` URL used in the canonical link as part of your data in MQTT, as well as the dataset location in your discovery metadata.
 
 wis2box API

--- a/docs/source/user/setup.rst
+++ b/docs/source/user/setup.rst
@@ -40,13 +40,31 @@ Updated variables in ``dev.env``, for example:
 
 .. code-block:: bash
 
+   # data-directory on your host machine that will map to /data/wis2box on the wis2box-container
    WIS2BOX_HOST_DATADIR=/home/wis2box-user/wis2box-data
    
-   WIS2BOX_BROKER_USERNAME=wis2box-mqtt-user
-   WIS2BOX_BROKER_PASSWORD=<your-unique-password>
-   
-   WIS2BOX_STORAGE_USERNAME=wis2box-storage-user
-   WIS2BOX_STORAGE_PASSWORD=<your-unique-password>
+   # update broker default credentials
+   WIS2BOX_BROKER_USERNAME=wis2box-user
+   WIS2BOX_BROKER_PASSWORD=wis2box123
+   WIS2BOX_BROKER_HOST=mosquitto
+   WIS2BOX_BROKER_PORT=1883
+
+   WIS2BOX_BROKER_PUBLIC=mqtt://${WIS2BOX_BROKER_USERNAME}:${WIS2BOX_BROKER_PASSWORD}@mosquitto:1883
+
+   # update storage default credentials
+   WIS2BOX_STORAGE_USERNAME=wis2box-user
+   WIS2BOX_STORAGE_PASSWORD=wis2box123
+
+   # set logging and data retention
+   WIS2BOX_LOGGING_LOGLEVEL=INFO
+   WIS2BOX_DATA_RETENTION_DAYS=30
+
+   # update minio settings after updating storage and broker defaults
+   MINIO_ROOT_USER=${WIS2BOX_STORAGE_USERNAME}
+   MINIO_ROOT_PASSWORD=${WIS2BOX_STORAGE_PASSWORD}
+   MINIO_NOTIFY_MQTT_USERNAME_WIS2BOX=${WIS2BOX_BROKER_USERNAME}
+   MINIO_NOTIFY_MQTT_PASSWORD_WIS2BOX=${WIS2BOX_BROKER_PASSWORD}
+   MINIO_NOTIFY_MQTT_BROKER_WIS2BOX=tcp://${WIS2BOX_BROKER_HOST}:${WIS2BOX_BROKER_PORT}
 
 Data mappings
 -------------

--- a/docs/source/user/setup.rst
+++ b/docs/source/user/setup.rst
@@ -207,7 +207,7 @@ Which should display the following:
 
 Refer to the :ref:`troubleshooting` section if this is not the case. 
 
-You should now be able to view collections on the wis2box API by visiting ``http://localhost:8999/oapi/collections`` in a web browser, which should appear as follows:
+You should now be able to view collections on the wis2box API by visiting ``http://localhost/oapi/collections`` in a web browser, which should appear as follows:
 
 .. image:: ../_static/wis2box-api-initial.png
   :width: 800
@@ -247,7 +247,7 @@ The first step is add the new dataset as defined by the YAML file for your disco
 
    If you see an error like ``ValueError: No plugins for XXX defined in data mappings``, exit the wis2box-container and edit the ``data-mappings.yml`` file in the directory defined by ``WIS2BOX_HOST_DATADIR``
 
-You can view the collection you just added, by re-visiting ``http://localhost:8999/oapi/collections`` in a web browser.
+You can view the collection you just added, by re-visiting ``http://localhost/oapi/collections`` in a web browser.
 
 .. image:: ../_static/wis2box-api-added-collection.png
   :width: 800
@@ -261,7 +261,7 @@ The second step is to publish discovery metadata and cache its content in the wi
 
 This command publishes an MQTT message with information about your dataset to the WIS2 Global Discovery Catalogue. Repeat this command whenever you have to provide updated metadata about your dataset.
 
-You can review the discovery metadata just cached through the new link in  ``http://localhost:8999/oapi/collections``:
+You can review the discovery metadata just cached through the new link in  ``http://localhost/oapi/collections``:
 
 .. image:: ../_static/wis2box-api-discovery-metadata.png
   :width: 800
@@ -273,7 +273,7 @@ The final step is to publish your station information to the wis2box API from th
 
    wis2box metadata station publish-collection
 
-You can review the stations you just cached through the new link in  ``http://localhost:8999/oapi/collections``:
+You can review the stations you just cached through the new link in  ``http://localhost/oapi/collections``:
 
 .. image:: ../_static/wis2box-api-stations.png
   :width: 800

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -188,7 +188,7 @@ def test_data_api():
 def test_message_api():
     """Test message API collection queries"""
 
-    url = f'{API_URL}/collections/messages/items?sortby=wigos_station_identifier'  # noqa
+    url = f'{API_URL}/collections/messages/items?sortby=-datetime'
     r = SESSION.get(url).json()
 
     assert r['numberMatched'] == 212
@@ -201,7 +201,8 @@ def test_message_api():
     assert msg['geometry'] is not None
 
     props = msg['properties']
-    assert props['datetime'] == '2023-01-18T00:00:00Z'
+    print(props)
+    assert props['datetime'] == '2023-01-18T12:00:00Z'
     assert props['wigos_station_identifier'] == '0-20000-0-15015'
     assert props['integrity']['method'] == 'sha512'
     assert props['data_id'].startswith('wis2')


### PR DESCRIPTION
this fixes the inconsistency when installing from the archive, though 8999 is still referenced multiple times in the reference guide. 