### PR TITLE
update to Elasticsearch 8 and latest pygeoapi, add wis2box-ui-admin

### DIFF
--- a/.github/workflows/tests-docker.yml
+++ b/.github/workflows/tests-docker.yml
@@ -40,7 +40,7 @@ jobs:
         docker logs wis2box-management
     - name: setup wis2box-management ⚙️
       run: |
-        sleep 10
+        sleep 30
         python3 wis2box-ctl.py execute wis2box environment show
     - name: add Malawi data 🇲🇼
       env:

--- a/default.env
+++ b/default.env
@@ -25,6 +25,9 @@ WIS2BOX_BROKER_PUBLIC=mqtt://wis2box:wis2box@mosquitto:1883
 WIS2BOX_BASEMAP_URL=https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
 WIS2BOX_BASEMAP_ATTRIBUTION=<a href="https://osm.org/copyright">OpenStreetMap</a> contributors
 
+# Admin UI
+WIS2BOX_UI_ADMIN_BASEURL=/admin
+
 # other
 WIS2BOX_URL=http://localhost
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,8 +62,8 @@ services:
     restart: always
     environment:
       - discovery.type=single-node
+      - discovery.seed_hosts=[]
       - node.name=elasticsearch-01
-      - discovery.seed_hosts=elasticsearch-01
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - cluster.name=es-wis2box

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
 
   wis2box-api:
     container_name: wis2box-api
-    image: ghcr.io/wmo-im/wis2box-api:0.5.1
+    image: ghcr.io/wmo-im/wis2box-api:latest
     restart: always
     env_file:
       - default.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
 
   wis2box-ui:
     container_name: wis2box-ui
-    image: ghcr.io/wmo-im/wis2box-ui:latest
+    image: ghcr.io/wmo-im/wis2box-ui:0.5.3
     restart: always
     env_file:
       - default.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,16 @@ services:
     depends_on:
       - wis2box-api
 
+#  wis2box-ui-admin:
+#    container_name: wis2box-ui-admin
+#    image: ghcr.io/wmo-im/wis2box-ui-admin:latest
+#    restart: always
+#    env_file:
+#      - default.env
+#      - dev.env
+#    depends_on:
+#      - wis2box-api
+
   wis2box-api:
     container_name: wis2box-api
     image: ghcr.io/wmo-im/wis2box-api:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
 
   elasticsearch:
     container_name: elasticsearch
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.6.2
     restart: always
     environment:
       - discovery.type=single-node

--- a/docs/source/reference/data-access/r-api.ipynb
+++ b/docs/source/reference/data-access/r-api.ipynb
@@ -152,7 +152,7 @@
       "  \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m      \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m      \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m       \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m  \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m     \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m    \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m \u001b[3m\u001b[90m<chr>\u001b[39m\u001b[23m \n",
       "\u001b[90m1\u001b[39m data.core… \u001b[90m\"\u001b[39m[ { \\\"sc… Surf… Surface we… \u001b[90m\"\u001b[39m[ { … \u001b[90m\"\u001b[39m[ { \\\"n… en       data… \u001b[90m\"\u001b[39m{ \\\"…\n",
       "\u001b[90m# … with 5 more variables: created <date>, rights <chr>,\u001b[39m\n",
-      "\u001b[90m#   X_metadata.anytext <chr>, id <chr>, geometry <POLYGON [°]>\u001b[39m\n"
+      "\u001b[90m#   id <chr>, geometry <POLYGON [°]>\u001b[39m\n"
      ]
     }
    ],

--- a/docs/source/reference/quickstart.rst
+++ b/docs/source/reference/quickstart.rst
@@ -8,7 +8,7 @@ It is the minimal runtime configuration profile as used in wis2box GitHub CI/CD:
 
 .. note:: wis2box web components are run on port 80 by default.  When using wis2box from source, the default port for web components is 8999, to be used for development.
 
-To download the wis2box from source: 
+To download wis2box from source:
 
 .. code-block:: bash
 

--- a/docs/source/reference/running/api-publishing.rst
+++ b/docs/source/reference/running/api-publishing.rst
@@ -25,12 +25,10 @@ will generate local station collection GeoJSON for API publication.
    wis2box metadata station publish-collection
 
 
-.. note:: run the command ``wis2box metadata station publish-collection`` to
-          publish your stations as a collection to the wis2box API
-
+.. note:: This command also runs automatically at startup and thereafter every 10 minutes
+          to keep your stations up to date.
 
 .. seealso:: :ref:`station-metadata`
-
 
 
 Discovery metadata API publishing

--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -67,7 +67,9 @@
         location / {
             proxy_pass http://wis2box-ui:80;
         }
-
+#        location /admin/ {
+#            proxy_pass http://wis2box-ui-admin:80/;
+#        }
         location /auth {
             internal;
             proxy_pass http://wis2box-auth:80/authorize;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -64,7 +64,9 @@
         location / {
             proxy_pass http://wis2box-ui:80;
         }
-
+#        location /admin/ {
+#            proxy_pass http://wis2box-ui-admin:80/;
+#        }
         location /auth {
             internal;
             proxy_pass http://wis2box-auth:80/authorize;

--- a/wis2box-management/docker/entrypoint.sh
+++ b/wis2box-management/docker/entrypoint.sh
@@ -43,6 +43,7 @@ cd ~/.pywcmp/wis2-topic-hierarchy && unzip -j /tmp/all.json.zip
 wis2box environment create
 wis2box environment show
 wis2box api setup
+wis2box metadata discovery setup
 wis2box metadata station publish-collection
 echo "END /entrypoint.sh"
 exec "$@"

--- a/wis2box-management/docker/wis2box.cron
+++ b/wis2box-management/docker/wis2box.cron
@@ -1,4 +1,4 @@
 0 0 * * * su wis2box -c "wis2box data clean --days=$WIS2BOX_DATA_RETENTION_DAYS" > /proc/1/fd/1 2>/proc/1/fd/2
 0 1 * * * su wis2box -c "wis2box data archive" > /proc/1/fd/1 2>/proc/1/fd/2
-*/10 * * * * su wis2box -c "wis2box metadata station publish-collection" > /proc/1/fd/1 2>/proc/1/fd/2
+#*/10 * * * * su wis2box -c "wis2box metadata station publish-collection" > /proc/1/fd/1 2>/proc/1/fd/2
 */10 * * * * su wis2box -c "echo 'wis2box.cron is alive'" > /proc/1/fd/1 2>/proc/1/fd/2

--- a/wis2box-management/docker/wis2box.cron
+++ b/wis2box-management/docker/wis2box.cron
@@ -1,4 +1,4 @@
 0 0 * * * su wis2box -c "wis2box data clean --days=$WIS2BOX_DATA_RETENTION_DAYS" > /proc/1/fd/1 2>/proc/1/fd/2
 0 1 * * * su wis2box -c "wis2box data archive" > /proc/1/fd/1 2>/proc/1/fd/2
-#*/10 * * * * su wis2box -c "wis2box metadata station publish-collection" > /proc/1/fd/1 2>/proc/1/fd/2
+*/10 * * * * su wis2box -c "wis2box metadata station publish-collection" > /proc/1/fd/1 2>/proc/1/fd/2
 */10 * * * * su wis2box -c "echo 'wis2box.cron is alive'" > /proc/1/fd/1 2>/proc/1/fd/2

--- a/wis2box-management/requirements.txt
+++ b/wis2box-management/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch<8
+elasticsearch
 isodate
 minio
 OWSLib

--- a/wis2box-management/wis2box/api/config/pygeoapi.py
+++ b/wis2box-management/wis2box/api/config/pygeoapi.py
@@ -111,8 +111,9 @@ class PygeoapiConfig(BaseConfig):
         else:
             resource_id = meta['topic_hierarchy']
 
-        if meta['id'] in ['discovery-metadata', 'stations']:
-            editable = True
+        # TODO: uncomment once admin UI is implemented
+        # if meta['id'] in ['discovery-metadata', 'stations']:
+        #     editable = True
 
         LOGGER.debug(f'Resource id: {resource_id}')
 

--- a/wis2box-management/wis2box/api/config/pygeoapi.py
+++ b/wis2box-management/wis2box/api/config/pygeoapi.py
@@ -104,10 +104,15 @@ class PygeoapiConfig(BaseConfig):
         :returns: `dict` of collection configuration
         """
 
+        editable = False
+
         if meta['id'] in ['discovery-metadata', 'messages', 'stations']:
             resource_id = meta['id']
         else:
             resource_id = meta['topic_hierarchy']
+
+        if meta['id'] in ['discovery-metadata', 'stations']:
+            editable = True
 
         LOGGER.debug(f'Resource id: {resource_id}')
 
@@ -131,6 +136,7 @@ class PygeoapiConfig(BaseConfig):
             },
             'providers': [{
                 'type': type_,
+                'editable': editable,
                 'name': provider_name,
                 'data': f'{API_BACKEND_URL}/{resource_id}',
                 'id_field': meta.get('id_field'),

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -155,6 +155,16 @@ def discovery_metadata():
 
 @click.command()
 @click.pass_context
+@cli_helpers.OPTION_VERBOSITY
+def setup(ctx, verbosity):
+    """Initializes metadata repository"""
+
+    click.echo('Setting up discovery metadata repository')
+    setup_collection(meta=gcm())
+
+
+@click.command()
+@click.pass_context
 @cli_helpers.ARGUMENT_FILEPATH
 @cli_helpers.OPTION_VERBOSITY
 def publish(ctx, filepath, verbosity):
@@ -188,4 +198,5 @@ def unpublish(ctx, identifier, verbosity):
 
 
 discovery_metadata.add_command(publish)
+discovery_metadata.add_command(setup)
 discovery_metadata.add_command(unpublish)

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -98,16 +98,6 @@ class DiscoveryMetadata(BaseMetadata):
         LOGGER.debug('Generating OARec discovery metadata')
         record = WMOWCMP2OutputSchema().write(md, stringify=False)
 
-        anytext_bag = [
-            md['identification']['title'],
-            md['identification']['abstract']
-        ]
-
-        for k, v in md['identification']['keywords'].items():
-            anytext_bag.extend(v['keywords'])
-
-        record['properties']['_metadata-anytext'] = ' '.join(anytext_bag)
-
         return record
 
 


### PR DESCRIPTION
In support of #154 

- updates to ES8
- updates based on latest pygeoapi (https://github.com/wmo-im/wis2box-api/pull/25)
- adds editable endpoints for metadata resources (metadata UI)
  - POST/PUT/DELETE commands on `/oapi/collections/discovery-metadata` and `/oapi/collections/stations` will need admin auth

❗❗❗  Note: this is a breaking change❗❗❗

Users will need to clear their ES data with:

```bash
docker volume rm wis2box_project_es-data
docker volume rm wis2box_project_api-config
```

...before installing the forthcoming 1.0.b2 release.

As an alternative workaround, from the elasticsearch container:
```bash
curl -XDELETE http://localhost:9200/discovery-metadata
curl -XDELETE http://localhost:9200/stations
```

...however we would have to verify that the observations are intact with the ES 7-> ES 8 upgrade.

The above will need to be added to the release notes.