### PR TITLE
pin nbsphinx for RTD build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 ipython_genutils
 jinja2==3.0.3
 jupyter
-nbsphinx
+nbsphinx<0.9
 pyzmq==23.2.1
 pypandoc
 sphinx

--- a/docs/source/user/data-ingest.rst
+++ b/docs/source/user/data-ingest.rst
@@ -53,11 +53,11 @@ Or by visiting the local Grafana instance running at ``http://localhost:3000``
 wis2box workflow monitoring
 ---------------------------
 
-The Grafana homepage shows an overview with the number of files received, new files produced and WIS2-notifications published.
+The Grafana homepage shows an overview with the number of files received, new files produced and WIS2 notifications published.
 
-The `Station data publishing status`-panel (on the left side) shows an overview of notifications and failures per configured station.
+The `Station data publishing status` panel (on the left side) shows an overview of notifications and failures per configured station.
 
-The `wis2box ERRORs`-panel (on the bottom) prints all ERROR-messages reported by the wis2box-management container.
+The `wis2box ERRORs` panel (on the bottom) prints all ERROR messages reported by the wis2box-management container.
 
 .. image:: ../_static/grafana-homepage.png
     :width: 800


### PR DESCRIPTION
This PR pins nbsphinx to `<0.9` given a possible issue in https://github.com/spatialaudio/nbsphinx/issues/720, which breaks building on RTD.