### PR TITLE
avoid installing wis2box as a Python egg

### DIFF
--- a/wis2box-management/Dockerfile
+++ b/wis2box-management/Dockerfile
@@ -59,6 +59,7 @@ RUN apt-get update -y && apt-get install -y ${DEBIAN_PACKAGES} \
 COPY . /app
 # install wis2box
 RUN cd /app \
+    # install wis2box as an editable package in /app/wis2box
     && pip3 install -e . \
     # install wis2box plugins, if defined
     && $PIP_PLUGIN_PACKAGES \

--- a/wis2box-management/Dockerfile
+++ b/wis2box-management/Dockerfile
@@ -59,7 +59,7 @@ RUN apt-get update -y && apt-get install -y ${DEBIAN_PACKAGES} \
 COPY . /app
 # install wis2box
 RUN cd /app \
-    && python3 setup.py install \
+    && pip3 install -e . \
     # install wis2box plugins, if defined
     && $PIP_PLUGIN_PACKAGES \
     # add wis2box user


### PR DESCRIPTION
Installs the wis2box package (in the wis2box-management container) as an editable package, which is useful for in-container debugging as required.