### PR TITLE
add custom header for wis2box-auth detection of API transactions

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,10 @@ services:
     volumes:
       - ../wis2box-api/wis2box_api:/app/wis2box_api
 
+  wis2box-auth:
+    volumes:
+      - ../wis2box-auth/wis2box_auth:/app/wis2box_auth
+
   elasticsearch:
     ports:
       - 9200:9200

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -60,7 +60,7 @@
             auth_request /auth;
             auth_request_set $auth_status $upstream_status;
             proxy_pass http://wis2box-api:80;
-            add_header X-api-http-method $request_method;
+            add_header X-api-http-method $request_method 'always';
         }
         location / {
             proxy_pass http://wis2box-ui:80;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -60,7 +60,7 @@
             auth_request /auth;
             auth_request_set $auth_status $upstream_status;
             proxy_pass http://wis2box-api:80;
-            add_header X-OGC-API-http-method $request_method;
+            add_header X-api-http-method $request_method;
         }
         location / {
             proxy_pass http://wis2box-ui:80;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -60,6 +60,7 @@
             auth_request /auth;
             auth_request_set $auth_status $upstream_status;
             proxy_pass http://wis2box-api:80;
+            add_header X-OGC-API-http-method $request_method;
         }
         location / {
             proxy_pass http://wis2box-ui:80;

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -57,10 +57,10 @@
             proxy_pass http://minio:9000;
         }
         location /oapi {
+            set $x_api_http_method $request_method;
             auth_request /auth;
             auth_request_set $auth_status $upstream_status;
             proxy_pass http://wis2box-api:80;
-            add_header X-api-http-method $request_method 'always';
         }
         location / {
             proxy_pass http://wis2box-ui:80;
@@ -71,8 +71,8 @@
         location /auth {
             internal;
             proxy_pass http://wis2box-auth:80/authorize;
-            proxy_pass_request_body off;
             proxy_set_header        Content-Length "";
+            proxy_set_header        X-api-http-method $x_api_http_method;
             proxy_set_header        X-Original-URI $request_uri;
             proxy_set_header        Authorization $http_authorization;
             proxy_pass_header       Authorization;

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -173,7 +173,7 @@ def make(args) -> None:
             run(args, split(f"{DOCKER_COMPOSE_COMMAND} {docker_compose_args} start {containers}"))
         else:
             if args.command == 'start-dev':
-                run(args, split(f'{DOCKER_COMPOSE_COMMAND} {docker_compose_args} --file docker-compose.dev.yml up'))
+                run(args, split(f'{DOCKER_COMPOSE_COMMAND} {docker_compose_args} --file docker-compose.dev.yml up -d'))
             else:
                 run(args, split(f'{DOCKER_COMPOSE_COMMAND} {docker_compose_args} up -d'))
     elif args.command == "execute":


### PR DESCRIPTION
Sets custom header on `/oapi` endpoint to help wis2box-auth detect whether a given request is an API Transaction.

Related: https://github.com/wmo-im/wis2box-auth/pull/5