### PR TITLE
WIP: Addition of keycloak for auth

### DIFF
--- a/default.env
+++ b/default.env
@@ -46,7 +46,39 @@ WIS2BOX_STORAGE_PUBLIC=wis2box-public
 WIS2BOX_STORAGE_ARCHIVE=wis2box-archive
 WIS2BOX_STORAGE_DATA_RETENTION_DAYS=7
 
+# Below: postgres and keycloak username and password default to storage username
+# and password until docs and `examples/config/wis2box.env` (dev.env) are updated.
+
+# postgresql
+POSTGRES_USER=${WIS2BOX_STORAGE_USERNAME}
+POSTGRES_PASSWORD=${WIS2BOX_STORAGE_PASSWORD}
+POSTGRES_DB=wis2box-database
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+# keycloak
+KEYCLOAK_ADMIN=${WIS2BOX_STORAGE_USERNAME}
+KEYCLOAK_ADMIN_PASSWORD=${WIS2BOX_STORAGE_PASSWORD}
+OAUTH2_PROXY_CLIENT_SECRET=<WIP-paste-from-keycloak>
+OAUTH2_PROXY_COOKIE_SECRET=<WIP-generate-and-keep-secure>
+
 # you should be okay from here
+
+# keycloak db access
+KC_PROXY=edge
+KC_HTTP_PORT=8180
+KC_DB_URL=jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+KC_DB_USERNAME=${POSTGRES_USER}
+KC_DB_PASSWORD=${POSTGRES_PASSWORD}
+
+# oauth2-proxy settings
+OAUTH2_PROXY_REVERSE_PROXY=true
+OAUTH2_PROXY_PROVIDER=keycloak-oidc
+OAUTH2_PROXY_SCOPE=openid
+OAUTH2_PROXY_CLIENT_ID=wis2box
+OAUTH2_PROXY_REDIRECT_URL=${WIS2BOX_URL}/oauth2/callback
+OAUTH2_PROXY_OIDC_ISSUER_URL=${WIS2BOX_URL}:8180/realms/wis2box
+OAUTH2_PROXY_CODE_CHALLENGE_METHOD=S256
 
 # MinIO
 MINIO_ROOT_USER=${WIS2BOX_STORAGE_USERNAME}

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -18,3 +18,12 @@ services:
     ports:
       - 1883:1883
       - 8884:8884
+
+  postgres:
+    ports:
+      - 5432:5432
+
+  keycloak:
+    ports:
+      - 8180:8180
+      - 4180:4180

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - wis2box-ui
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./nginx/oauth2-conf.inc:/etc/nginx/conf.d/oauth2-conf.inc
+      - ./nginx/protect-location.inc:/etc/nginx/conf.d/protect-location.inc
 
   wis2box-ui:
     container_name: wis2box-ui
@@ -131,6 +133,26 @@ services:
         condition: service_healthy
     command: ["wis2box", "pubsub" , "subscribe", "--broker", "http://wis2box-minio:9000", "--topic", "wis2box-storage/#"]
 
+  postgres:
+    container_name: postgres
+    image: postgres:13
+    volumes:
+      - postgres-db-volume:/var/lib/postgresql/data
+    env_file:
+      - default.env
+
+  keycloak:
+    # WIP-FIXME: --hostname-strict must be true in production (use docker-compose.ssl.yml)
+    container_name: keycloak
+    command: start --optimized --hostname-strict=false 
+    build: keycloak
+    volumes:
+      - keycloak-data-volume:/opt/keycloak/data
+    env_file:
+      - default.env
+    depends_on:
+      - postgres
+
   wis2box-auth:
     container_name: wis2box-auth
     image: ghcr.io/wmo-im/wis2box-auth:latest
@@ -148,3 +170,5 @@ volumes:
   minio-data:
   auth-data:
   api-config:
+  postgres-db-volume:
+  keycloak-data-volume:

--- a/keycloak/Dockerfile
+++ b/keycloak/Dockerfile
@@ -1,0 +1,16 @@
+FROM quay.io/keycloak/keycloak:20.0.3
+WORKDIR /opt/keycloak/
+
+RUN ./bin/kc.sh build --db=postgres
+
+# WIP-FIXME: Downloading oauth2-proxy **uncompressed** binary from non-standard location
+# To fix see https://www.keycloak.org/server/containers to add `tar` via `dnf` package manager
+USER root
+RUN curl -Lo /opt/keycloak/oauth2-proxy https://github.com/isedwards/wis2box-auth/raw/oauth2-proxy-bin/oauth2-proxy && \
+    chown keycloak /opt/keycloak/oauth2-proxy && chmod +x /opt/keycloak/oauth2-proxy
+COPY entrypoint.sh /opt/keycloak/
+RUN chown keycloak /opt/keycloak/entrypoint.sh && chmod +x /opt/keycloak/entrypoint.sh
+USER keycloak
+
+# Replace standard entrypoint ("/opt/keycloak/bin/kc.sh")
+ENTRYPOINT [ "/opt/keycloak/entrypoint.sh" ]

--- a/keycloak/README
+++ b/keycloak/README
@@ -1,0 +1,19 @@
+# Overview
+
+Currently, wis2box is using [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) to interface with [keycloak](https://www.keycloak.org) to reduce the complexity and risk when managing cookies and user sessions.
+
+oauth2-proxy provides a single configuration setting called `--oidc-issuer-url` to reference the keycloak instance. This creates a problem when deploying the system on `localhost`.
+
+1. **Inside the Container**: When oauth2-proxy attempts to make a connection directly to keycloak, it views `localhost` as the container's internal environment and therefore we cannot access keycloak at `localhost:8180`. Thus, for `--oidc-issuer-url`, we must provide the service's private network address (e.g., `http://keycloak:8180`).
+
+2. **User's Browser Context**: Once the direct connection is established, oauth2-proxy sends a redirect to the browser for logging in via the OIDC provider. Since the browser operates in your machine's context, and is not aware of `http://keycloak:8180`. The redirection needs to be to the host's `localhost`, e.g. `http://localhost:8180`.
+
+Unfortunately, a single `--oidc-issuer-url` cannot satisfy both requirements. 
+
+# Workaround
+
+The simplest short-term workaround is to include oauth2-proxy within the keycloak container to provide a comprehensive solution in a single location. This solves the `localhost` issue because direct connections from oauth2-proxy to keycloak at `localhost:8180` are fulfilled within the shared container, whereas redirects to `localhost:8180` can be fulfilled by the host machine.
+
+## Work in progress (WIP)
+
+The keycloak container is running a minimal installation of RHEL 8.7 and doesn't have a package manager or tools like `tar` (which would be needed to install `oauth2-proxy`). To resolve this issue we need to follow the instructions at https://www.keycloak.org/server/containers to install `tar`. However, the minimal RHEL image does have `curl` therefore, as a short-term workaround, we currently provide an uncompressed version of oauth2-proxy v7.5.0 (retrieved using `curl -L https://github.com/oauth2-proxy/oauth2-proxy/releases/download/v7.5.0/oauth2-proxy-v7.5.0.linux-amd64.tar.gz | tar xz`). The SHA for the uncompressed download can be checked on the oauth2-proxy [releases page](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.5.0).

--- a/keycloak/entrypoint.sh
+++ b/keycloak/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Replacing the default keycloak entrypoint with a version that manages both
+# keycloak and oauth2-proxy processes. This script is PID 1 in the container.
+
+# Start keycloak in the background with the passed arguments
+/opt/keycloak/bin/kc.sh "$@" &
+
+# Get the PID of the Keycloak process
+keycloak_pid=$!
+
+# Wait for Keycloak to be accessible
+while ! curl -s http://localhost:8180/auth > /dev/null; do
+  echo "Waiting for Keycloak to start..."
+  sleep 5
+done
+
+# Start oauth2-proxy in the background
+# If you don't whitelist keycloak's domain (and port) then redirects to keycloak will be ignored
+# WIP-FIXME: get keycloak location from envvar and remove above comment
+/opt/keycloak/oauth2-proxy \
+  --email-domain=* \
+  --http-address=":4180" \
+  --insecure-oidc-allow-unverified-email \
+  --skip-provider-button \
+  --set-xauthrequest \
+  --pass-access-token \
+  --set-authorization-header \
+  --whitelist-domain localhost:8180 \
+  &
+
+# Get the PID of the oauth2-proxy process
+oauth2_proxy_pid=$!
+
+# Function to handle termination and stop the services gracefully
+terminate_processes() {
+  # Kill the oauth2-proxy process
+  kill "$oauth2_proxy_pid" || true
+  
+  # Kill the Keycloak process
+  kill "$keycloak_pid" || true
+
+  # Wait for background processes to shut down
+  wait
+  exit 0
+}
+
+# Trap SIGTERM and SIGINT signals and call terminate_processes
+trap 'terminate_processes' SIGTERM SIGINT
+
+# Wait indefinitely (for background processes) while keeping the script alive
+wait

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -21,6 +21,8 @@
         gzip_proxied no-cache no-store private expired auth;
         gzip_min_length 1000;
 
+        include /etc/nginx/conf.d/oauth2-conf.inc;
+
         # Proxy requests to the bucket "wis2box-incoming" to MinIO container running on port 9000
         # NOTE do not use rewrite, it crashes the upload
         location /wis2box-incoming/ {
@@ -39,7 +41,8 @@
         }
         location /data {
             # FIXME: derive alias from environment variables
-            auth_request /auth;
+            include /etc/nginx/conf.d/protect-location.inc;
+
             auth_request_set $auth_status $upstream_status;
 
             proxy_set_header X-Real-IP $remote_addr;
@@ -57,7 +60,7 @@
             proxy_pass http://minio:9000;
         }
         location /oapi {
-            auth_request /auth;
+            include /etc/nginx/conf.d/protect-location.inc;
             auth_request_set $auth_status $upstream_status;
             proxy_pass http://wis2box-api:80;
         }
@@ -67,13 +70,4 @@
 #        location /admin/ {
 #            proxy_pass http://wis2box-ui-admin:80/;
 #        }
-        location /auth {
-            internal;
-            proxy_pass http://wis2box-auth:80/authorize;
-            proxy_pass_request_body off;
-            proxy_set_header        Content-Length "";
-            proxy_set_header        X-Original-URI $request_uri;
-            proxy_set_header        Authorization $http_authorization;
-            proxy_pass_header       Authorization;
-        }
     }

--- a/nginx/oauth2-conf.inc
+++ b/nginx/oauth2-conf.inc
@@ -1,0 +1,64 @@
+# WIP-FIXME: use envsubst to replace hardcoded http://localhost:8180/
+
+location = /login {
+    return 302 /oauth2/start?rd=$scheme://$host;
+}
+
+location = /logout {
+    # Internally redirect to the signout endpoint of oauth2-proxy and also signout of keycloak
+    proxy_pass http://keycloak:4180/oauth2/sign_out?rd=http://localhost:8180/realms/wis2box/protocol/openid-connect/logout;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Scheme $scheme;
+}
+
+location = /auth {
+    # We use auth_request with oauth2-proxy in order to add X-User, X-Email and X-Group headers
+    # see `protect-location.inc` for example use.
+    internal;
+    auth_request /oauth2/auth;
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+    proxy_set_header X-Original-URI $request_uri;
+
+    # Handle 200 OK and 401 Unauthorized responses
+    # In both cases we defer to wis2box-auth to actually authorize requests
+    proxy_pass http://wis2box-auth:80/authorize;  # oauth2-proxy has added headers (authenticated user)
+    error_page 401 = /authorize;  # no additional headers have been added (anonymous user)
+}
+
+location = /authorize {
+    internal;
+    proxy_pass http://wis2box-auth:80/authorize;
+    proxy_pass_request_body off;
+    proxy_set_header        Content-Length "";
+    proxy_set_header        X-Original-URI $request_uri;
+    proxy_set_header        Authorization $http_authorization;
+    proxy_pass_header       Authorization;
+}
+
+# ----------------------------------------------------
+# The configuration below is taken directly from
+# https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview#configuring-for-use-with-the-nginx-auth_request-directive
+# See also: https://oauth2-proxy.github.io/oauth2-proxy/docs/features/endpoints/
+
+location /oauth2/ {
+    proxy_pass       http://keycloak:4180;
+    proxy_set_header Host                    $host;
+    proxy_set_header X-Real-IP               $remote_addr;
+    proxy_set_header X-Scheme                $scheme;
+    proxy_set_header X-Auth-Request-Redirect $request_uri;
+    # or, if you are handling multiple domains:
+    # proxy_set_header X-Auth-Request-Redirect $scheme://$host$request_uri;
+}
+
+location = /oauth2/auth {
+    proxy_pass       http://keycloak:4180;
+    proxy_set_header Host             $host;
+    proxy_set_header X-Real-IP        $remote_addr;
+    proxy_set_header X-Scheme         $scheme;
+    # nginx auth_request includes headers but not body
+    proxy_set_header Content-Length   "";
+    proxy_pass_request_body           off;
+}

--- a/nginx/protect-location.inc
+++ b/nginx/protect-location.inc
@@ -1,0 +1,15 @@
+# Sanitize original request headers to remove any claims originating externally
+proxy_set_header X-User   "";
+proxy_set_header X-Email  "";
+proxy_set_header X-Groups "";
+
+auth_request /auth;
+
+# Set X-User, X-Email and X-Groups from oauth2-proxy 
+# (requires running oauth2-proxy with --set-xauthrequest flag)
+auth_request_set $user $upstream_http_x_auth_request_preferred_username;  
+auth_request_set $email $upstream_http_x_auth_request_email;  
+auth_request_set $groups $upstream_http_x_auth_request_groups;  
+proxy_set_header X-User $user;
+proxy_set_header X-Email $email;
+proxy_set_header X-Groups $groups;


### PR DESCRIPTION
- Adds keycloak and postgres containers
- Adds additional nginx config

The proposed changes work with wis2box's existing architecture without altering any of the existing functionality.

Three additions are required before a first version can be merged:
- [ ] Minor update is required to `nginx/oauth2-conf.inc` to ensure that the `X-Groups` header added by oauth2-proxy is  forwarded to wis2box-auth
- [ ] Updates to wis2box-auth's `app.py` are required to: 
    1. Add `add_group` and `remove_group` (equivalent to existing `add_token` and `remove_token`)
    2. In addition to authorizing requests that are public, or where a simple token is included in the request, `authorize` will also authorize requests where the user's group (defined in keycloak and available to wis2box-auth in the `X-Groups` header) has permission to access the topic
- [ ] Docs and tests