### PR TITLE
discovery metadata/notification message updates

### DIFF
--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -141,8 +141,10 @@ def test_metadata_discovery_publish():
         assert link['type'] == 'application/geo+json'
         assert link['href'].endswith('json')
 
-        r = SESSION.get(link['href']).json()
+        r = SESSION.get(link['href'])
+        assert r.headers['Content-Type'] == 'application/geo+json'
 
+        r = r.json()
         assert r['conformsTo'][0] == 'http://wis.wmo.int/spec/wcmp/2/conf/core'
 
 

--- a/wis2box-management/wis2box/data/base.py
+++ b/wis2box-management/wis2box/data/base.py
@@ -145,10 +145,10 @@ class BaseAbstractData:
         LOGGER.debug(f'Prepare message for: {storage_path}')
 
         topic = f'origin/a/wis2/{self.topic_hierarchy.dirpath}'
-        data_id_topic = topic.replace('origin/a/', '')
+        data_id = topic.replace('origin/a/wis2', '')
 
         wis_message = WISNotificationMessage(
-            identifier, data_id_topic, storage_path, datetime_, geometry,
+            identifier, data_id, storage_path, datetime_, geometry,
             wigos_station_identifier)
 
         # load plugin for public broker

--- a/wis2box-management/wis2box/data/base.py
+++ b/wis2box-management/wis2box/data/base.py
@@ -145,7 +145,7 @@ class BaseAbstractData:
         LOGGER.debug(f'Prepare message for: {storage_path}')
 
         topic = f'origin/a/wis2/{self.topic_hierarchy.dirpath}'
-        data_id = topic.replace('origin/a/wis2', '')
+        data_id = topic.replace('origin/a/wis2/', '')
 
         wis_message = WISNotificationMessage(
             identifier, data_id, storage_path, datetime_, geometry,

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -226,7 +226,7 @@ def publish(ctx, filepath, verbosity):
 
         data_bytes = json.dumps(record,
                                 default=json_serial).encode('utf-8')
-        storage_path = f"{STORAGE_SOURCE}/{STORAGE_PUBLIC}/metadata/{record['id']}"  # noqa
+        storage_path = f"{STORAGE_SOURCE}/{STORAGE_PUBLIC}/metadata/{record['id']}.json"  # noqa
 
         put_data(data_bytes, storage_path)
 

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -228,7 +228,7 @@ def publish(ctx, filepath, verbosity):
                                 default=json_serial).encode('utf-8')
         storage_path = f"{STORAGE_SOURCE}/{STORAGE_PUBLIC}/metadata/{record['id']}.json"  # noqa
 
-        put_data(data_bytes, storage_path)
+        put_data(data_bytes, storage_path, 'application/geo+json')
 
         message = publish_broker_message(record, storage_path,
                                          record_mcf['wis2box']['country'],

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -21,7 +21,7 @@
 
 import click
 from copy import deepcopy
-from datetime import datetime
+from datetime import date, datetime
 import json
 import logging
 
@@ -65,6 +65,11 @@ class DiscoveryMetadata(BaseMetadata):
         md['identification']['wmo_topic_hierarchy'] = local_topic
         LOGGER.debug('Adding revision date')
         md['identification']['dates']['revision'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
+
+        LOGGER.debug('Checking temporal extents')
+        if md['identification']['extents']['temporal'][0].get('begin', 'BEGIN_DATE') is None:  # noqa
+            today = date.today().strftime('%Y-%m-%d')
+            md['identification']['extents']['temporal'][0]['begin'] = today
 
         LOGGER.debug('Adding distribution links')
         oafeat_link = {
@@ -115,6 +120,14 @@ class DiscoveryMetadata(BaseMetadata):
                 record['properties']['contacts'][0]['phones'][0]['value'] = f'+{phone}'  # noqa
         except KeyError:
             LOGGER.debug('No phone number defined')
+
+        try:
+            postalcode = record['properties']['contacts'][0]['addresses'][0]['postalcode']  # noqa
+            if isinstance(postalcode, int):
+                record['properties']['contacts'][0]['addresses'][0]['postalcode'] = f'{postalcode}'  # noqa
+        except KeyError:
+            LOGGER.debug('No phone number defined')
+            pass
 
         return record
 
@@ -211,7 +224,7 @@ def publish(ctx, filepath, verbosity):
 
         record = dm.generate(record_mcf)
 
-        data_bytes = json.dumps(record_mcf,
+        data_bytes = json.dumps(record,
                                 default=json_serial).encode('utf-8')
         storage_path = f"{STORAGE_SOURCE}/{STORAGE_PUBLIC}/metadata/{record['id']}"  # noqa
 

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -126,7 +126,7 @@ class DiscoveryMetadata(BaseMetadata):
             if isinstance(postalcode, int):
                 record['properties']['contacts'][0]['addresses'][0]['postalcode'] = f'{postalcode}'  # noqa
         except KeyError:
-            LOGGER.debug('No phone number defined')
+            LOGGER.debug('No postal code defined')
             pass
 
         return record

--- a/wis2box-management/wis2box/pubsub/message.py
+++ b/wis2box-management/wis2box/pubsub/message.py
@@ -131,13 +131,18 @@ class WISNotificationMessage(PubSubMessage):
         super().__init__('wis2-notification-message', identifier,
                          topic, filepath, datetime_, geometry)
 
-        suffix = self.filepath.split('.')[-1]
-        try:
-            mimetype = DATA_OBJECT_MIMETYPES[suffix]
-        except KeyError:
-            mimetype = 'application/octet-stream'
+        data_id = f'{topic}/{self.identifier}'.replace('origin/a/wis2/', '')
 
-        # replace storage-source with wis2box-url
+        if '/metadata' in topic:
+            mimetype = 'application/geo+json'
+        else:
+            suffix = self.filepath.split('.')[-1]
+            mimetype = DATA_OBJECT_MIMETYPES.get(suffix,
+                'application/octet-stream')  # noqa
+
+        LOGGER.debug(f'media type: {mimetype}')
+
+        # replace storage source with wis2box URL
         public_file_url = self.filepath.replace(
             f'{STORAGE_SOURCE}/{STORAGE_PUBLIC}', f'{URL}/data'
         )
@@ -151,7 +156,7 @@ class WISNotificationMessage(PubSubMessage):
             'version': 'v04',
             'geometry': self.geometry,
             'properties': {
-                'data_id': f'{topic}/{self.identifier}',
+                'data_id': data_id,
                 'datetime': self.datetime,
                 'pubtime': self.publish_datetime,
                 'integrity': {

--- a/wis2box-management/wis2box/storage/__init__.py
+++ b/wis2box-management/wis2box/storage/__init__.py
@@ -87,11 +87,14 @@ def list_content(basepath: str) -> Any:
     return storage.list_objects(prefix)
 
 
-def put_data(data: bytes, path: str) -> Any:
+def put_data(data: bytes, path: str,
+             content_type: str = 'application/octet-stream') -> Any:
     """
     Put data into storage
 
     :param data: bytes of object/file
+    :param path: path to use object id
+    :param content_type: media type (default is `application/octet-stream`)
 
     :returns: content of object/file
     """
@@ -113,7 +116,7 @@ def put_data(data: bytes, path: str) -> Any:
     identifier = storage_path.replace(name, '')
 
     LOGGER.debug(f'Storing data into {identifier}')
-    return storage.put(data, identifier)
+    return storage.put(data, identifier, content_type)
 
 
 def delete_data(path: str) -> Any:

--- a/wis2box-management/wis2box/storage/base.py
+++ b/wis2box-management/wis2box/storage/base.py
@@ -73,12 +73,14 @@ class StorageBase:
 
         raise NotImplementedError()
 
-    def put(self, data: bytes, identifier: str) -> bool:
+    def put(self, data: bytes, identifier: str,
+            content_type: str = 'application/octet-stream') -> bool:
         """
         Access data source from storage
 
         :param data: bytes of file to upload
         :param identifier: `str` of data dest identifier
+        :param content_type: media type (default is `application/octet-stream`)
 
         :returns: `bool` of put result
         """

--- a/wis2box-management/wis2box/storage/minio.py
+++ b/wis2box-management/wis2box/storage/minio.py
@@ -151,10 +151,12 @@ class MinIOStorage(StorageBase):
 
         return data
 
-    def put(self, data: bytes, identifier: str) -> bool:
+    def put(self, data: bytes, identifier: str,
+            content_type: str = 'application/octet-stream') -> bool:
 
         LOGGER.debug(f'Putting data as object={identifier}')
         self.client.put_object(bucket_name=self.name, object_name=identifier,
+                               content_type=content_type,
                                data=BytesIO(data), length=-1,
                                part_size=10*1024*1024)
 

--- a/wis2box-management/wis2box/storage/s3.py
+++ b/wis2box-management/wis2box/storage/s3.py
@@ -47,10 +47,15 @@ class S3Storage(StorageBase):
 
         return data['Body'].read()
 
-    def put(self, filepath: Path, identifier: str) -> bool:
+    def put(self, filepath: Path, identifier: str,
+            content_type: str = 'application/octet-stream') -> bool:
 
         LOGGER.debug(f'Putting file {filepath} to {identifier}')
-        self.client.upload_file(filepath, self.name, identifier)
+        extra_args = {
+            'ContentType': content_type
+        }
+        self.client.upload_file(filepath, self.name, identifier,
+                                ExtraArgs=extra_args)
 
         return True
 


### PR DESCRIPTION
- update notification message for discovery metadata
  - ensure canonical link points to WCMP2 document (not MCF)
  - ensure media type is `application/geo+json`
- ensure notification messages do not include any part of `origin/a/wis2`
- update discovery metadata
  - ensure contact postalcode is always a string
  - ensure temporal begin date is set, if not set by user before publishing
- set media type in storage