### PR TITLE
use input wsi instead of returned value

### DIFF
--- a/wis2box-management/wis2box/metadata/station.py
+++ b/wis2box-management/wis2box/metadata/station.py
@@ -405,7 +405,7 @@ def get(ctx, wsi, verbosity):
 
     results = OrderedDict({
         'station_name': station['station_name'],
-        'wigos_station_identifier': station['wigos_station_identifier'],
+        'wigos_station_identifier': wsi,
         'traditional_station_identifier': None,
         'facility_type': station['facility_type'],
         'latitude': station.get('latitude', ''),


### PR DESCRIPTION
While working with Brazil I noted that they used secondary primary IDs from their stations in OSCAR. In order to create a working station-list for their data the secondary wsi needs to be inserted in their station-metadata, requiring this minor fix.