### PR TITLE
updates WCMP2 docs, examples and pywis-topics

### DIFF
--- a/config-templates/metadata-synop.yml.tmpl
+++ b/config-templates/metadata-synop.yml.tmpl
@@ -33,7 +33,7 @@ identification:
             keywords_type: theme
             vocabulary:
                 name: WMO WIS2 Topic Hierarchy
-                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline.csv
+                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv
     extents:
         spatial:
             - bbox: [$BOUNDING_BOX]

--- a/config-templates/metadata-temp.yml.tmpl
+++ b/config-templates/metadata-temp.yml.tmpl
@@ -34,7 +34,7 @@ identification:
             keywords_type: theme
             vocabulary:
                 name: WMO WIS2 Topic Hierarchy
-                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline.csv
+                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv
     extents:
         spatial:
             - bbox: [$BOUNDING_BOX]

--- a/docs/source/user/setup.rst
+++ b/docs/source/user/setup.rst
@@ -181,6 +181,10 @@ You can review the discovery metadata just cached through the new item at  ``/oa
 
 Repeat this step for any other discovery metadata you wish to publish, such as the ``temp`` dataset.
 
+.. note::
+
+   You must ensure that your discovery metadata is published once the WMO Global Broker is connected and subscribed for your wis2box broker.  If you have published discovery metadata before this stage, you must re-publish using the command above.
+
 Finally it is recommended to prepare authentication tokens for updating your stations and ingesting data using the wis2box-webapp.
 
 To create a token for ingesting data:

--- a/docs/source/user/setup.rst
+++ b/docs/source/user/setup.rst
@@ -183,7 +183,7 @@ Repeat this step for any other discovery metadata you wish to publish, such as t
 
 .. note::
 
-   You must ensure that your discovery metadata is published once the WMO Global Broker is connected and subscribed for your wis2box broker.  If you have published discovery metadata before this stage, you must re-publish using the command above.
+   To ensure that discovery metadata is shared with the WIS2 Global Discovery Catalogue, you must ensure that your discovery metadata is published once the WMO Global Broker is connected and subscribed for your wis2box broker.  If you have published discovery metadata before this stage, you must re-publish using the command above.
 
 Finally it is recommended to prepare authentication tokens for updating your stations and ingesting data using the wis2box-webapp.
 

--- a/examples/config/surface-weather-observations.yml
+++ b/examples/config/surface-weather-observations.yml
@@ -33,7 +33,7 @@ identification:
             keywords_type: theme
             vocabulary:
                 name: WMO WIS2 Topic Hierarchy
-                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline.csv
+                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv
     extents:
         spatial:
             - bbox: [-180, -90, 190, 90]

--- a/tests/data/metadata/discovery/cog-surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/cog-surface-weather-observations.yml
@@ -28,7 +28,7 @@ identification:
             keywords_type: theme
             vocabulary:
                 name: Earth system disciplines as defined by the WMO Unified Data Policy, Resolution 1 (Cg-Ext(2021), Annex 1.
-                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline.csv
+                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv
     extents:
         spatial:
             - bbox: [11.0937728207,-5.03798674888,18.4530652198,3.72819651938]

--- a/tests/data/metadata/discovery/dza-surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/dza-surface-weather-observations.yml
@@ -28,7 +28,7 @@ identification:
             keywords_type: theme
             vocabulary:
                 name: Earth system disciplines as defined by the WMO Unified Data Policy, Resolution 1 (Cg-Ext(2021), Annex 1.
-                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline.csv
+                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv
     extents:
         spatial:
             - bbox: [-8.68439978681, 19.0573642034, 11.9995056495, 37.1183806422]

--- a/tests/data/metadata/discovery/ita-surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/ita-surface-weather-observations.yml
@@ -28,7 +28,7 @@ identification:
             keywords_type: theme
             vocabulary:
                 name: Earth system disciplines as defined by the WMO Unified Data Policy, Resolution 1 (Cg-Ext(2021), Annex 1.
-                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline.csv
+                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv
     extents:
         spatial:
             - bbox: [6.74995, 36.61998, 18.48024, 47.11539]

--- a/tests/data/metadata/discovery/mwi-surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/mwi-surface-weather-observations.yml
@@ -28,7 +28,7 @@ identification:
             keywords_type: theme
             vocabulary:
                 name: Earth system disciplines as defined by the WMO Unified Data Policy, Resolution 1 (Cg-Ext(2021), Annex 1.
-                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline.csv
+                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv
     extents:
         spatial:
             - bbox: [32.6881653175,-16.8012997372,35.7719047381,-9.23059905359]

--- a/tests/data/metadata/discovery/rou-synoptic-weather-observations.yml
+++ b/tests/data/metadata/discovery/rou-synoptic-weather-observations.yml
@@ -28,7 +28,7 @@ identification:
             keywords_type: theme
             vocabulary:
                 name: Earth system disciplines as defined by the WMO Unified Data Policy, Resolution 1 (Cg-Ext(2021), Annex 1.
-                url: https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline.csv
+                url:  https://github.com/wmo-im/wis2-topic-hierarchy/blob/main/topic-hierarchy/earth-system-discipline/index.csv
     extents:
         spatial:
             - bbox: [20.2201924985,43.6884447292,29.62654341,48.2208812526]

--- a/wis2box-management/Dockerfile
+++ b/wis2box-management/Dockerfile
@@ -45,7 +45,7 @@ RUN apt-get update -y && apt-get install -y ${DEBIAN_PACKAGES} \
     https://github.com/wmo-cop/pyoscar/archive/refs/tags/0.6.4.zip \
     https://github.com/wmo-im/synop2bufr/archive/refs/tags/v0.6.2.zip \
     https://github.com/geopython/pygeometa/archive/master.zip \
-    https://github.com/wmo-im/pywcmp/archive/refs/tags/0.4.0.zip \
+    https://github.com/wmo-im/pywis-topics/archive/refs/tags/0.2.0.zip \
     # install shapely
     && pip3 install --no-cache-dir cython pygeos==0.13 \
     && pip3 install shapely \

--- a/wis2box-management/docker/entrypoint.sh
+++ b/wis2box-management/docker/entrypoint.sh
@@ -33,11 +33,8 @@ printenv | grep -v "no_proxy" >> /etc/environment
 service cron start
 service cron status
 
-echo "Caching topic hierarchy JSON"
-rm -fr /tmp/all.json /tmp/all.json.zip ~/.pywcmp/wis2-topic-hierarchy
-mkdir -p ~/.pywcmp/wis2-topic-hierarchy
-curl https://wmo-im.github.io/wis2-topic-hierarchy/all.json.zip --output /tmp/all.json.zip
-cd ~/.pywcmp/wis2-topic-hierarchy && unzip -j /tmp/all.json.zip
+echo "Caching topic hierarchy CSVs"
+pywis-topics bundle sync
 
 # wis2box commands
 # TODO: avoid re-creating environment if it already exists

--- a/wis2box-management/requirements.txt
+++ b/wis2box-management/requirements.txt
@@ -6,5 +6,6 @@ OWSLib
 paho-mqtt
 pygeometa
 pywis-pubsub
+pywis-topics
 PyYAML
 requests

--- a/wis2box-management/wis2box/topic_hierarchy.py
+++ b/wis2box-management/wis2box/topic_hierarchy.py
@@ -24,8 +24,8 @@ import logging
 from pathlib import Path
 from typing import Any, Tuple, Union
 
-# TODO: uncomment once topic hiearchy is approved
-# from pywcmp.wcmp2.topics import TopicHierarchy as pywcmp_th
+# from pywis_topics.topics import TopicHierarchy as pywis_topics_th
+
 from wis2box.data_mappings import DATADIR_DATA_MAPPINGS
 from wis2box.plugin import load_plugin
 
@@ -37,6 +37,11 @@ class TopicHierarchy:
         self.path = str(path)
         self.dotpath = None
         self.dirpath = None
+
+        if not self.path.startswith('origin/a/wis2'):
+            self.fullpath = f'origin/a/wis2/{self.dirpath}'
+        else:
+            self.fullpath = self.dirpath
 
         if '/' in self.path:
             LOGGER.debug('Transforming from directory to dotted path')
@@ -54,10 +59,10 @@ class TopicHierarchy:
         :returns: `bool` of whether the topic hierarchy is valid
         """
 
-        # TODO: uncomment once topic hiearchy is approved
+        # TODO: uncomment once WTH is approved
         # LOGGER.debug(f'Validating topic {self.dirpath} (fuzzy match)')
-        # th = pywcmp_th()
-        # return th.validate(self.dirpath, fuzzy=True)
+        # th = pywis_topics_th()
+        # return th.validate(self.fullpath)
 
         return True
 


### PR DESCRIPTION
Fixes #532.  In addition, updates WCMP2 MCFs to the latest WTH lookups.  Finally, use [pywis-topics](https://github.com/wmo-im/pywis-topics) (which was pulled out of pywcmp) for WTH handling (note that WTH handling continues to be commented out until WTH is officially approved).