### PR TITLE
Update station topic

### DIFF
--- a/docs/source/community/troubleshooting.rst
+++ b/docs/source/community/troubleshooting.rst
@@ -5,7 +5,28 @@ Troubleshooting
 
 This page lists several commonly seen issues and how to address them.
 
+no station on map in wis2box-UI
+-------------------------------
+
+The stations displayed in the wis2box-ui per dataset are defined by the topic associated with the station.
+
+To associate a station with a topic, you can edit the station metadata using the station-editor in wis2box-webapp or you can use the command 'wis2box metadata station add-topic' to add a topic to a station.
+
+For example, to add the topic 'origin/a/wis2/my-centre-id/data/core/weather/surface-based-observations/synop' to the station with wigos-station-id=0-20000-0-12345, run the following command:
+
+.. code-block:: bash
+
+   python3 wis2box-ctl.py login
+   wis2box metadata station add-topic --wsi 0-20000-0-12345 origin/a/wis2/my-centre-id/data/core/weather/surface-based-observations/synop
 	
+To associated all stations defined in your station metadata with the same topic, you can use the command 'wis2box metadata station add-topic' without specifying a station id:
+
+.. code-block:: bash
+
+   python3 wis2box-ctl.py login
+   wis2box metadata station add-topic origin/a/wis2/my-centre-id/data/core/weather/surface-based-observations/synop
+
+
 OSError: Missing data mappings
 ------------------------------
 
@@ -92,6 +113,7 @@ To add missing stations, use the station-editor in wis2box-webapp (from wis2box-
 
    python3 wis2box-ctl.py login
    wis2box metadata station publish-collection
+
 
 Error: no such container: wis2box-management
 --------------------------------------------

--- a/docs/source/community/troubleshooting.rst
+++ b/docs/source/community/troubleshooting.rst
@@ -5,21 +5,21 @@ Troubleshooting
 
 This page lists several commonly seen issues and how to address them.
 
-no station on map in wis2box-UI
+No station on map in wis2box-UI
 -------------------------------
 
 The stations displayed in the wis2box-ui per dataset are defined by the topic associated with the station.
 
-To associate a station with a topic, you can edit the station metadata using the station-editor in wis2box-webapp or you can use the command 'wis2box metadata station add-topic' to add a topic to a station.
+To associate a station with a topic, you can edit the station metadata using the station editor in wis2box-webapp or you can use the command ``wis2box metadata station add-topic`` to add a topic to a station.
 
-For example, to add the topic 'origin/a/wis2/my-centre-id/data/core/weather/surface-based-observations/synop' to the station with wigos-station-id=0-20000-0-12345, run the following command:
+For example, to add the topic ``origin/a/wis2/my-centre-id/data/core/weather/surface-based-observations/synop`` to the station with the WIGOS station identifier ``0-20000-0-12345``, run the following command:
 
 .. code-block:: bash
 
    python3 wis2box-ctl.py login
    wis2box metadata station add-topic --wsi 0-20000-0-12345 origin/a/wis2/my-centre-id/data/core/weather/surface-based-observations/synop
 	
-To associated all stations defined in your station metadata with the same topic, you can use the command 'wis2box metadata station add-topic' without specifying a station id:
+To associated all stations defined in your station metadata with the same topic, you can use the command ``wis2box metadata station add-topic`` without specifying a station identifier:
 
 .. code-block:: bash
 

--- a/docs/source/user/setup.rst
+++ b/docs/source/user/setup.rst
@@ -232,6 +232,23 @@ You can also bulk insert a set of stations from a CSV file, by defining the stat
 
 After doing a bulk insert please review the stations in wis2box-webapp and associate each station to the correct topics.
 
+Adding topics to stations from the command line
+-----------------------------------------------
+
+If you want to associate all stations in your station metadata to one topic, you can use the following command:
+
+.. code-block:: bash
+
+   python3 wis2box-ctl.py login
+   wis2box metadata station add-topic <topic-id>
+
+If you want to add a topic to a single station, you can use the following command:
+
+.. code-block:: bash
+
+   python3 wis2box-ctl.py login
+   wis2box metadata station add-topic --wsi <station-id> <topic-id>
+
 The next is the :ref:`data-ingest`.
 
 .. _`wis2box Releases`: https://github.com/wmo-im/wis2box/releases

--- a/wis2box-management/wis2box/api/__init__.py
+++ b/wis2box-management/wis2box/api/__init__.py
@@ -124,6 +124,19 @@ def upsert_collection_item(collection_id: str, item: dict) -> str:
     return True
 
 
+def reindex_collection(collection_id: str, new_collection_id: str) -> str:
+    """
+    Reindex a collection
+
+    :param collection_id: name of collection
+    :param new_collection_id: name of new collection
+
+    :returns: `str` identifier of added item
+    """
+    backend = load_backend()
+    backend.reindex_collection(collection_id, new_collection_id)
+
+
 def delete_collection_item(collection_id: str, item_id: str) -> str:
     """
     Delete an item from a collection
@@ -173,7 +186,7 @@ def setup(ctx, verbosity):
 @cli_helpers.ARGUMENT_FILEPATH
 @cli_helpers.OPTION_VERBOSITY
 def add_collection(ctx, filepath, verbosity):
-    """Delete collection from api backend"""
+    """Add collection from api backend"""
 
     if not setup_collection(meta=filepath.read()):
         click.echo('Unable to add collection')

--- a/wis2box-management/wis2box/api/__init__.py
+++ b/wis2box-management/wis2box/api/__init__.py
@@ -133,8 +133,13 @@ def reindex_collection(collection_id: str, new_collection_id: str) -> str:
 
     :returns: `str` identifier of added item
     """
+
+    api_config = load_config()
+    collection_data = api_config.get_collection_data(collection_id)
+    new_collection_data = api_config.get_collection_data(new_collection_id)
+
     backend = load_backend()
-    backend.reindex_collection(collection_id, new_collection_id)
+    backend.reindex_collection(collection_data, new_collection_data)
 
 
 def delete_collection_item(collection_id: str, item_id: str) -> str:

--- a/wis2box-management/wis2box/api/backend/base.py
+++ b/wis2box-management/wis2box/api/backend/base.py
@@ -73,6 +73,18 @@ class BaseBackend:
 
         raise NotImplementedError()
 
+    def reindex_collection(self, source: str, destination: str) -> bool:
+        """
+        Reindex a collection
+
+        :param source: name of source collection
+        :param destination: name of destination collection
+
+        :returns: `bool` of reindex result
+        """
+
+        raise NotImplementedError()
+
     def upsert_collection_item(self, collection: str, item: dict) -> str:
         """
         Add or update a collection item

--- a/wis2box-management/wis2box/api/backend/elastic.py
+++ b/wis2box-management/wis2box/api/backend/elastic.py
@@ -255,16 +255,7 @@ class ElasticBackend(BaseBackend):
         es_index_source = self.es_id(collection_id_source)
         es_index_target = self.es_id(collection_id_target)
 
-        if self.has_collection(collection_id_target):
-            # delete existing index
-            LOGGER.debug(f'Deleting index={collection_id_target}')
-            self.conn.indices.delete(index=collection_id_target)
-
-        self.conn.options().indices.create(index=collection_id_target,
-                                           mappings=MAPPINGS,
-                                           settings=SETTINGS)
-
-        LOGGER.info(f'Copying {es_index_source} to {es_index_target}')
+        print(f'Copying {es_index_source} to {es_index_target}')
         try:
             helpers.reindex(self.conn, es_index_source, es_index_target)
         except helpers.BulkIndexError as e:

--- a/wis2box-management/wis2box/api/backend/elastic.py
+++ b/wis2box-management/wis2box/api/backend/elastic.py
@@ -259,9 +259,9 @@ class ElasticBackend(BaseBackend):
         try:
             helpers.reindex(self.conn, es_index_source, es_index_target)
         except helpers.BulkIndexError as e:
-            print("Bulk indexing failed for some documents:")
+            LOGGER.error('Bulk indexing failed for some documents:')
             for err in e.errors:
-                print(err)
+                LOGGER.error(err)
 
         return self.has_collection(collection_id_target)
 

--- a/wis2box-management/wis2box/data/__init__.py
+++ b/wis2box-management/wis2box/data/__init__.py
@@ -27,7 +27,8 @@ import click
 
 from wis2box import cli_helpers
 from wis2box.api import (setup_collection, remove_collection,
-                         delete_collections_by_retention)
+                         delete_collections_by_retention,
+                         reindex_collection)
 from wis2box.data_mappings import DATADIR_DATA_MAPPINGS
 from wis2box.env import (STORAGE_SOURCE, STORAGE_ARCHIVE, STORAGE_PUBLIC,
                          STORAGE_DATA_RETENTION_DAYS, STORAGE_INCOMING)
@@ -233,6 +234,18 @@ def delete_collection(ctx, collection, verbosity):
 
 @click.command()
 @click.pass_context
+@click.argument('collection_id_source')
+@click.argument('collection_id_target')
+def reindex_collection_items(ctx, collection_id_source, collection_id_target):
+    """Reindex items from one collection to another"""
+
+    reindex_collection(collection_id_source, collection_id_target)
+
+    click.echo('Done')
+
+
+@click.command()
+@click.pass_context
 @cli_helpers.OPTION_TOPIC_HIERARCHY
 @cli_helpers.OPTION_PATH
 @cli_helpers.OPTION_RECURSIVE
@@ -255,3 +268,4 @@ data.add_command(ingest)
 data.add_command(add_collection)
 data.add_command(delete_collection)
 data.add_command(add_collection_items)
+data.add_command(reindex_collection_items)

--- a/wis2box-management/wis2box/metadata/station.py
+++ b/wis2box-management/wis2box/metadata/station.py
@@ -274,7 +274,7 @@ def add_topic_hierarchy(new_topic: str, territory_name: str, wsi: str) -> None:
         msg = f'ERROR: Invalid topic: {new_topic}\n'
         msg += 'Valid topics:\n'
         msg += '\n'.join(valid_topics)
-        print(msg)
+        LOGGER.error(msg)
         return
 
     stations = load_stations()

--- a/wis2box-management/wis2box/metadata/station.py
+++ b/wis2box-management/wis2box/metadata/station.py
@@ -271,11 +271,11 @@ def add_topic_hierarchy(new_topic: str, territory_name: str, wsi: str) -> None:
 
     valid_topics = [topic for link, topic in load_datasets()]
     if new_topic not in valid_topics:
-        msg = f' ! Invalid topic: {new_topic} !\n'
+        msg = f'ERROR: Invalid topic: {new_topic}\n'
         msg += 'Valid topics:\n'
         msg += '\n'.join(valid_topics)
-        LOGGER.error(msg)
-        raise RuntimeError(msg)
+        print(msg)
+        return
 
     stations = load_stations()
     for feature in stations.values():

--- a/wis2box-management/wis2box/metadata/station.py
+++ b/wis2box-management/wis2box/metadata/station.py
@@ -257,6 +257,7 @@ def check_station_datasets(wigos_station_identifier: str) -> Iterator[dict]:
             topic['topic'] = topic2.replace('origin/a/wis2/', '')
             yield topic
 
+
 def add_topic_hierarchy(new_topic: str, territory_name: str, wsi: str) -> None:
     """
     Adds topic hierarchy to topic
@@ -282,7 +283,7 @@ def add_topic_hierarchy(new_topic: str, territory_name: str, wsi: str) -> None:
             continue
         if territory_name != 'any' and feature['properties']['territory_name'] != territory_name:  # noqa
             continue
-        
+
         topics = feature['properties'].get('topics', [])
         # remove topics not in valid_topics
         topics = [x for x in topics if x in valid_topics]
@@ -297,6 +298,7 @@ def add_topic_hierarchy(new_topic: str, territory_name: str, wsi: str) -> None:
         except RuntimeError as err:
             LOGGER.debug(f'Station does not exist: {err}')
         upsert_collection_item('stations', feature)
+
 
 def publish_from_csv() -> None:
     """


### PR DESCRIPTION
Updates to assist migration to new topic-hierarchy and to assist users in associating station with a topic
- new option to 'add-topic' to stations in station-metadata
- new option to copy data between collections by reindexing