### PR TITLE
add update link

### DIFF
--- a/wis2box-management/wis2box/pubsub/message.py
+++ b/wis2box-management/wis2box/pubsub/message.py
@@ -171,7 +171,14 @@ class WISNotificationMessage(PubSubMessage):
                 'type': mimetype,
                 'href': public_file_url,
                 'length': self.length
-            }]
+            },
+            {
+                'rel': 'http://def.wmo.int/def/rel/wnm/-/update',
+                'type': mimetype,
+                'href': public_file_url,
+                'length': self.length
+            }
+            ]
         }
 
         if self.length < 4096:

--- a/wis2box-management/wis2box/pubsub/message.py
+++ b/wis2box-management/wis2box/pubsub/message.py
@@ -166,18 +166,19 @@ class WISNotificationMessage(PubSubMessage):
                     'value': self.checksum_value
                 }
             },
-            'links': [{
-                'rel': 'canonical',
-                'type': mimetype,
-                'href': public_file_url,
-                'length': self.length
-            },
-            {
-                'rel': 'http://def.wmo.int/def/rel/wnm/-/update',
-                'type': mimetype,
-                'href': public_file_url,
-                'length': self.length
-            }
+            'links': [
+                {
+                    'rel': 'canonical',
+                    'type': mimetype,
+                    'href': public_file_url,
+                    'length': self.length
+                },
+                {
+                    'rel': 'http://def.wmo.int/def/rel/wnm/-/update',
+                    'type': mimetype,
+                    'href': public_file_url,
+                    'length': self.length
+                }
             ]
         }
 


### PR DESCRIPTION
To fix https://github.com/wmo-im/wis2box/issues/565

Any data send into the wis2box will publish a message with both the canonical and and the update-link

I want to avoid checking if the data is new or updated, this ensure that corrected-data will get redownloaded by downstream consumers.