### PR TITLE
safeguard paho-mqtt to <2

### DIFF
--- a/wis2box-management/requirements.txt
+++ b/wis2box-management/requirements.txt
@@ -3,7 +3,7 @@ iso3166
 isodate
 minio
 OWSLib
-paho-mqtt
+paho-mqtt<2
 pygeometa
 pywis-pubsub
 pywis-topics

--- a/wis2box-mqtt-metrics-collector/requirements.txt
+++ b/wis2box-mqtt-metrics-collector/requirements.txt
@@ -1,3 +1,3 @@
 prometheus-client
-paho-mqtt
+paho-mqtt<2
 requests


### PR DESCRIPTION
paho-mqtt 2 is now at RC2.  This PR pins to using 1.x.  We revisit the migration/upgrade once paho-mqtt 2 stable is released and tried/tested further.