### PR TITLE
Fix typo in nginx gzip types

### DIFF
--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -20,7 +20,7 @@
 
         sendfile on;
         gzip on;
-        gzip_types application/json application/geo+json text/css application/javscript text/plain;
+        gzip_types application/json application/geo+json text/css application/javascript text/plain;
         gzip_proxied no-cache no-store private expired auth;
         gzip_min_length 1000;
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -17,7 +17,7 @@
 
         sendfile on;
         gzip on;
-        gzip_types application/json application/geo+json text/css application/javscript text/plain;
+        gzip_types application/json application/geo+json text/css application/javascript text/plain;
         gzip_proxied no-cache no-store private expired auth;
         gzip_min_length 1000;
 


### PR DESCRIPTION
nginx has not been compressing `application/javascript` due to a typo in the header. Fixing this compresses wis2box-ui from 1.9mb to 726kb.