### PR TITLE
avoid unnecessary disk-space used by logs

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -16,6 +16,8 @@ x-logging: &logging
       mode: non-blocking
       max-buffer-size: 4m
       loki-retries: "3"
+      max-size: "10m"
+      max-file: 1
 
 services:
   # The Loki database for storing logs.


### PR DESCRIPTION

From the documentation
![image](https://github.com/wmo-im/wis2box/assets/19169339/88a8ff84-91ac-4576-9aa3-8b91a7adb3d4)

I updated the logging option for loki to add this options to reduce unnecessary disk-space usage by logs
