### PR TITLE
Issue 641

### DIFF
--- a/wis2box-management/docker/entrypoint.sh
+++ b/wis2box-management/docker/entrypoint.sh
@@ -38,6 +38,9 @@ wis2box environment create
 wis2box environment show
 wis2box api setup
 
+# test the wis2box is not misconfigured
+wis2box environment test
+
 # ensure cron is running
 service cron start
 service cron status

--- a/wis2box-management/wis2box/env.py
+++ b/wis2box-management/wis2box/env.py
@@ -127,7 +127,7 @@ def test(ctx, verbosity):
     broker = load_plugin('pubsub', defs)
 
     try:
-        result = broker.test(topic='origin/a/wis2/test', message='wis2box pub test')
+        result = broker.test(topic='origin/a/wis2/test', message='wis2box pub test') # noqa
     except Exception as err:
         LOGGER.error(err)
         raise EnvironmentError(err)
@@ -135,9 +135,10 @@ def test(ctx, verbosity):
     if result:
         click.echo('Broker test successful')
     else:
-        LOGGER.error('Could not connect to broker defined by WI2BOX_BROKER_PUBLIC')
+        LOGGER.error('Could not connect to broker defined by WI2BOX_BROKER_PUBLIC') # noqa
         click.echo('Broker test failed')
         exit(1)
+
 
 @click.command()
 @click.pass_context

--- a/wis2box-management/wis2box/env.py
+++ b/wis2box-management/wis2box/env.py
@@ -111,6 +111,37 @@ def environment():
 @click.command()
 @click.pass_context
 @cli_helpers.OPTION_VERBOSITY
+def test(ctx, verbosity):
+    """Tests the environment is set up correctly"""
+
+    click.echo(f'Setting up logging (loglevel={LOGLEVEL}, logfile={LOGFILE})')
+    setup_logger(LOGLEVEL, LOGFILE)
+
+    click.echo('Testing BROKER_PUBLIC')
+    # load plugin for plugin-broker
+    defs = {
+        'codepath': PLUGINS['pubsub']['mqtt']['plugin'],
+        'url': BROKER_PUBLIC,
+        'client_type': 'publisher'
+    }
+    broker = load_plugin('pubsub', defs)
+
+    try:
+        result = broker.test(topic='origin/a/wis2/test', message='wis2box pub test')
+    except Exception as err:
+        LOGGER.error(err)
+        raise EnvironmentError(err)
+
+    if result:
+        click.echo('Broker test successful')
+    else:
+        LOGGER.error('Could not connect to broker defined by WI2BOX_BROKER_PUBLIC')
+        click.echo('Broker test failed')
+        exit(1)
+
+@click.command()
+@click.pass_context
+@cli_helpers.OPTION_VERBOSITY
 def create(ctx, verbosity):
     """Creates baseline data/metadata directory structure"""
 
@@ -163,3 +194,4 @@ def show(ctx, verbosity):
 
 environment.add_command(create)
 environment.add_command(show)
+environment.add_command(test)

--- a/wis2box-management/wis2box/pubsub/base.py
+++ b/wis2box-management/wis2box/pubsub/base.py
@@ -64,6 +64,18 @@ class BasePubSubClient:
 
         raise NotImplementedError()
 
+    def test(self, topic='wis2box/test', message='test') -> bool:
+        """
+        Test the connection to the broker
+
+        :param topic: `str` of topic
+        :param message: `str` of message
+
+        :returns: `bool` of test result
+        """
+
+        raise NotImplementedError()
+
     def bind(self, event: str, function: Callable[..., Any]) -> None:
         """
         Binds an event to a function

--- a/wis2box-management/wis2box/pubsub/mqtt.py
+++ b/wis2box-management/wis2box/pubsub/mqtt.py
@@ -153,14 +153,14 @@ class MQTTPubSubClient(BasePubSubClient):
             else:
                 msg = f'Test: Failed to connect to MQTT-broker: {mqtt_client.connack_string(rc)}' # noqa
                 LOGGER.error(msg)
-        
+
         def on_message(client, userdata, message):
             LOGGER.debug(f'Test: Received message {message.payload.decode()}')
             self.test_status = 'success'
 
         self.conn.on_connect = on_connect
         self.conn.on_message = on_message
-    
+
         self.conn.loop_start()
         sleep(0.1)
         self.conn.publish(topic, message, qos=1)


### PR DESCRIPTION
Fix for https://github.com/wmo-im/wis2box/issues/641

Add 'wis2box environment test' in wis2box-management entrypoint.sh that check if the provided string for WIS2BOX_BROKER_PUBLIC can be used for publishing

I tested this locally by explicitly adding a typo in the password in WIS2BOX_BROKER_PUBLIC, causing the wis2box to bounce infinitely as reported in the Grafana dashboard:

![image](https://github.com/user-attachments/assets/d2a0151b-21a8-4ee6-9aed-72db70b98ecc)


With spelling mistake in host:
![image](https://github.com/user-attachments/assets/9e9c60d5-e898-428a-a712-da37f5f65fa3)
