### PR TITLE
MinIO version to support older CPUs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
   minio:
     container_name: wis2box-minio
-    image: minio/minio
+    image: minio/minio:RELEASE.2024-08-03T04-33-23Z-cpuv1
     mem_limit: 512m
     memswap_limit: 512m
     restart: always


### PR DESCRIPTION
Pin MinIO to latest cpuv1 release, to avoid the error: Fatal glibc error: CPU does not support x86-64-v2

See:
https://github.com/minio/minio/issues/18365