### PR TITLE
Issue 674 new

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,15 +5,27 @@ services:
       - ./wis2box-management/wis2box/wis2box.cron:/etc/cron.d/wis2box:ro
       - ./wis2box-management/wis2box:/app/wis2box
     command: ["wis2box", "pubsub" , "subscribe"]
+    depends_on:
+      - minio
+      - mosquitto
+      - wis2box-api
 
   wis2box-api:
     volumes:
       - ../wis2box-api/wis2box_api:/app/wis2box_api
+    depends_on:
+      - elasticsearch
 
   wis2box-auth:
     volumes:
       - ../wis2box-auth/wis2box_auth:/app/wis2box_auth
+    depends_on:
+      - wis2box-management
 
   elasticsearch:
     ports:
       - 9200:9200
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 5s
+      retries: 100

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -25,14 +25,12 @@ services:
     <<: *logging
     container_name: loki
     image: grafana/loki:2.4.1
+    restart: always
     command: -config.file=/etc/loki/loki-config.yml
     volumes:
       - loki-data:/loki
       - ./loki/loki-config.yml:/etc/loki/loki-config.yml
-    networks:
-      vpcbr: # this is the place where we assign the static ipv4 address
-        ipv4_address: 10.5.0.2
-      default:
+
   # mqtt_metrics_collector, listens to mqtt-broker
   mqtt_metrics_collector:
     <<: *logging
@@ -54,12 +52,16 @@ services:
     <<: *logging
     image: prom/prometheus:v2.37.0
     container_name: prometheus
+    restart: always
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - prometheus-data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=10d'
+    ports:
+      - "9090:9090"
+
   # uncomment cadvisor to monitor containers
   # cadvisor:
   #  image: gcr.io/cadvisor/cadvisor:v0.45.0
@@ -76,13 +78,15 @@ services:
   # Grafana, graphical monitoring dashboards for wis2box using data from loki and prometheus
   grafana:
     <<: *logging
+    image: grafana/grafana-oss:9.0.3
     container_name: grafana
+    restart: always
     env_file:
       - wis2box.env
-    image: grafana/grafana-oss:9.0.3
     volumes:
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
       - ./grafana/datasources:/etc/grafana/provisioning/datasources
+  # if alert want to link emails this place should mount local cofiguration to grafana
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_ADMIN_PASSWORD:-admin}
@@ -100,13 +104,22 @@ services:
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
     ports:
       - 3000:3000
+
+  # Elasticsearch Exporter for monitoring Elasticsearch metrics
+  elasticsearch-exporter:
+    <<: *logging
+    image: quay.io/prometheuscommunity/elasticsearch-exporter:latest
+    command:
+      - '--es.uri=http://elasticsearch:9200'
+      - '--es.indices_settings'
+    restart: always
+  elasticsearch:
+    <<: *logging
   wis2box-management:
     <<: *logging
   mosquitto:
     <<: *logging
   wis2box-api:
-    <<: *logging
-  elasticsearch:
     <<: *logging
   wis2box-auth:
     <<: *logging
@@ -120,3 +133,4 @@ services:
 volumes:
   loki-data:
   prometheus-data:
+

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -59,8 +59,6 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=10d'
-    ports:
-      - "9090:9090"
 
   # uncomment cadvisor to monitor containers
   # cadvisor:
@@ -78,11 +76,11 @@ services:
   # Grafana, graphical monitoring dashboards for wis2box using data from loki and prometheus
   grafana:
     <<: *logging
-    image: grafana/grafana-oss:9.0.3
     container_name: grafana
     restart: always
     env_file:
       - wis2box.env
+    image: grafana/grafana-oss:9.0.3
     volumes:
       - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
       - ./grafana/datasources:/etc/grafana/provisioning/datasources

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
 
   minio:
     container_name: wis2box-minio
-    image: minio/minio
+    image: minio/minio:RELEASE.2024-08-03T04-33-23Z-cpuv1
     mem_limit: 512m
     memswap_limit: 512m
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     image: ghcr.io/wmo-im/wis2box-webapp:latest
     env_file:
       - wis2box.env
+    restart: always
 
   wis2box-api:
     container_name: wis2box-api
@@ -51,7 +52,7 @@ services:
 
   minio:
     container_name: wis2box-minio
-    image: minio/minio:RELEASE.2024-08-03T04-33-23Z-cpuv1
+    image: minio/minio
     mem_limit: 512m
     memswap_limit: 512m
     restart: always
@@ -145,6 +146,7 @@ services:
 
   wis2downloader:
     container_name: wis2downloader
+    restart: always
     build: ./wis2downloader
     env_file:
       - wis2box.env

--- a/grafana/dashboards/elasticsearchhealthmonitoring.json
+++ b/grafana/dashboards/elasticsearchhealthmonitoring.json
@@ -1,0 +1,451 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "description": "show all alerting list",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 24,
+      "options": {
+        "alertName": "",
+        "dashboardAlerts": false,
+        "dashboardTitle": "",
+        "maxItems": 10,
+        "showOptions": "current",
+        "sortOrder": 1,
+        "stateFilter": {
+          "alerting": true,
+          "execution_error": false,
+          "no_data": false,
+          "ok": false,
+          "paused": false,
+          "pending": false
+        },
+        "tags": []
+      },
+      "pluginVersion": "",
+      "title": "Current Alerts Overview",
+      "type": "alertlist"
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                90
+              ],
+              "type": "gt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "message": "testing notifications",
+        "name": "Alert: High Storage Usage in Elasticsearch Cluster \"es-wis2box\"",
+        "noDataState": "no_data",
+        "notifications": [
+          {
+            "uid": "izXvIMCIz"
+          }
+        ]
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PABAFD29CE247021E"
+      },
+      "description": "Represents the percentage of disk space used on the Elasticsearch node. It shows how much of the total disk capacity is being utilized by Elasticsearch data.\nThe overall query computes the percentage of used storage in the filesystem for the specified Elasticsearch cluster (es-wis2box). If the result is, for example, 75%, it means that 75% of the filesystem is used and 25% is free.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-GrYlRd"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 18,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": 3600000,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "decimals": 0,
+          "displayName": "the percentage of used storage in the filesystem for the specified Elasticsearch cluster (es-wis2box)",
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "dark-red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "the percentage of used storage in the filesystem for the specified Elasticsearch cluster (es-wis2box)"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 3
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "sortBy": "Last",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PABAFD29CE247021E"
+          },
+          "editorMode": "code",
+          "expr": "100-(sum(elasticsearch_filesystem_data_free_bytes{cluster=\"es-wis2box\"})/sum(elasticsearch_filesystem_data_size_bytes{cluster=\"es-wis2box\"})*100)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "gt",
+          "value": 90,
+          "visible": true
+        }
+      ],
+      "title": "Elasticsearch Disk Space Utilization (%)",
+      "type": "timeseries",
+      "xaxis": {
+        "format": "time",
+        "label": "Time",
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": "Disk Usage (%)",
+          "show": true
+        },
+        {
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    },
+    {
+      "alert": {
+        "alertRuleTags": {},
+        "conditions": [
+          {
+            "evaluator": {
+              "params": [
+                10
+              ],
+              "type": "lt"
+            },
+            "operator": {
+              "type": "and"
+            },
+            "query": {
+              "params": [
+                "A",
+                "5m",
+                "now"
+              ]
+            },
+            "reducer": {
+              "params": [],
+              "type": "avg"
+            },
+            "type": "query"
+          }
+        ],
+        "executionErrorState": "alerting",
+        "for": "5m",
+        "frequency": "1m",
+        "handler": 1,
+        "message": "Block devices monitoring check",
+        "name": "Alert: Low Free Disk Space in Elasticsearch Cluster \"es-wis2box\"",
+        "noDataState": "no_data",
+        "notifications": []
+      },
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PABAFD29CE247021E"
+      },
+      "description": "Represents the total amount of free disk space, in gigabytes, available across all data nodes in the es-wis2box Elasticsearch cluster.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "continuous-RdYlGr",
+            "seriesBy": "last"
+          },
+          "custom": {
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 21,
+            "gradientMode": "hue",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineStyle": {
+              "fill": "solid"
+            },
+            "lineWidth": 2,
+            "pointSize": 9,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "line"
+            }
+          },
+          "displayName": "the total amount of free disk space, in gigabytes, available across all data nodes in the es-wis2box Elasticsearch cluster",
+          "mappings": [],
+          "max": 150,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "semi-dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-red",
+                "value": 10
+              },
+              {
+                "color": "yellow",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "decgbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 10
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom"
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PABAFD29CE247021E"
+          },
+          "editorMode": "code",
+          "expr": "sum(elasticsearch_filesystem_data_free_bytes{cluster=\"es-wis2box\"})/1024/1024/1024",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "op": "lt",
+          "value": 10,
+          "visible": true
+        }
+      ],
+      "title": "Elasticsearch Available Disk Space (GB)",
+      "type": "timeseries",
+      "xaxis": {
+        "format": "time",
+        "label": "Time",
+        "mode": "time",
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "GB",
+          "label": "Free Space (GB)",
+          "show": true
+        },
+        {
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "elasticsearch health monitoring dashboard",
+  "uid": "DZBIE-9Sz",
+  "version": 1,
+  "weekStart": ""
+}

--- a/grafana/dashboards/elasticsearchhealthmonitoring.json
+++ b/grafana/dashboards/elasticsearchhealthmonitoring.json
@@ -24,6 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 3,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -57,7 +58,7 @@
         },
         "tags": []
       },
-      "pluginVersion": "",
+      "pluginVersion": "9.0.3",
       "title": "Current Alerts Overview",
       "type": "alertlist"
     },
@@ -94,7 +95,7 @@
         "frequency": "1m",
         "handler": 1,
         "message": "testing notifications",
-        "name": "Alert: High Storage Usage in Elasticsearch Cluster \"es-wis2box\"",
+        "name": "Alert: Elasticsearch Disk Space Utilization > 90%",
         "noDataState": "no_data",
         "notifications": [
           {
@@ -110,7 +111,7 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "continuous-GrYlRd"
+            "mode": "thresholds"
           },
           "custom": {
             "axisLabel": "",
@@ -195,7 +196,7 @@
         ]
       },
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 24,
         "x": 0,
         "y": 3
@@ -262,42 +263,6 @@
       }
     },
     {
-      "alert": {
-        "alertRuleTags": {},
-        "conditions": [
-          {
-            "evaluator": {
-              "params": [
-                10
-              ],
-              "type": "lt"
-            },
-            "operator": {
-              "type": "and"
-            },
-            "query": {
-              "params": [
-                "A",
-                "5m",
-                "now"
-              ]
-            },
-            "reducer": {
-              "params": [],
-              "type": "avg"
-            },
-            "type": "query"
-          }
-        ],
-        "executionErrorState": "alerting",
-        "for": "5m",
-        "frequency": "1m",
-        "handler": 1,
-        "message": "Block devices monitoring check",
-        "name": "Alert: Low Free Disk Space in Elasticsearch Cluster \"es-wis2box\"",
-        "noDataState": "no_data",
-        "notifications": []
-      },
       "datasource": {
         "type": "prometheus",
         "uid": "PABAFD29CE247021E"
@@ -342,22 +307,21 @@
           },
           "displayName": "the total amount of free disk space, in gigabytes, available across all data nodes in the es-wis2box Elasticsearch cluster",
           "mappings": [],
-          "max": 150,
           "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
-                "color": "semi-dark-green",
+                "color": "red",
                 "value": null
               },
               {
-                "color": "dark-red",
-                "value": 10
+                "color": "yellow",
+                "value": 2
               },
               {
-                "color": "yellow",
-                "value": 20
+                "color": "green",
+                "value": 4
               }
             ]
           },
@@ -366,10 +330,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 5,
+        "h": 9,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 11
       },
       "id": 22,
       "options": {
@@ -399,14 +363,7 @@
           "refId": "A"
         }
       ],
-      "thresholds": [
-        {
-          "colorMode": "critical",
-          "op": "lt",
-          "value": 10,
-          "visible": true
-        }
-      ],
+      "thresholds": [],
       "title": "Elasticsearch Available Disk Space (GB)",
       "type": "timeseries",
       "xaxis": {

--- a/grafana/dashboards/home.json
+++ b/grafana/dashboards/home.json
@@ -24,10 +24,43 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "description": "show all the alerting list",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 14,
+      "options": {
+        "alertName": "",
+        "dashboardAlerts": false,
+        "dashboardTitle": "",
+        "maxItems": 10,
+        "showOptions": "current",
+        "sortOrder": 1,
+        "stateFilter": {
+          "alerting": true,
+          "execution_error": false,
+          "no_data": false,
+          "ok": false,
+          "paused": false,
+          "pending": false
+        },
+        "tags": []
+      },
+      "pluginVersion": "",
+      "title": "Current Alerts Overview",
+      "type": "alertlist"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -116,7 +149,7 @@
         "h": 15,
         "w": 10,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 12,
       "interval": "24h",
@@ -137,7 +170,7 @@
           }
         ]
       },
-      "pluginVersion": "9.0.3",
+      "pluginVersion": "",
       "targets": [
         {
           "datasource": {
@@ -329,7 +362,7 @@
         "h": 5,
         "w": 14,
         "x": 10,
-        "y": 0
+        "y": 3
       },
       "id": 2,
       "interval": "1m",
@@ -425,7 +458,7 @@
         "h": 5,
         "w": 14,
         "x": 10,
-        "y": 5
+        "y": 8
       },
       "id": 6,
       "interval": "1m",
@@ -520,7 +553,7 @@
         "h": 5,
         "w": 14,
         "x": 10,
-        "y": 10
+        "y": 13
       },
       "id": 10,
       "interval": "1m",
@@ -563,7 +596,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 15
+        "y": 18
       },
       "id": 8,
       "options": {
@@ -642,6 +675,6 @@
   "timezone": "",
   "title": "wis2box data publication dashboard",
   "uid": "KkBocEA4k",
-  "version": 4,
+  "version": 1,
   "weekStart": ""
 }

--- a/grafana/dashboards/wis2downloader.json
+++ b/grafana/dashboards/wis2downloader.json
@@ -24,10 +24,43 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
+    {
+      "datasource": {
+        "type": "datasource",
+        "uid": "grafana"
+      },
+      "description": "show all the alerting alert",
+      "gridPos": {
+        "h": 3,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 21,
+      "options": {
+        "alertName": "",
+        "dashboardAlerts": false,
+        "dashboardTitle": "",
+        "maxItems": 10,
+        "showOptions": "current",
+        "sortOrder": 1,
+        "stateFilter": {
+          "alerting": true,
+          "execution_error": false,
+          "no_data": false,
+          "ok": false,
+          "paused": false,
+          "pending": false
+        },
+        "tags": []
+      },
+      "pluginVersion": "",
+      "title": "Current Alerts Overview",
+      "type": "alertlist"
+    },
     {
       "datasource": {
         "type": "prometheus",
@@ -61,7 +94,7 @@
         "h": 6,
         "w": 9,
         "x": 0,
-        "y": 0
+        "y": 3
       },
       "id": 14,
       "options": {
@@ -148,7 +181,7 @@
         "h": 4,
         "w": 3,
         "x": 9,
-        "y": 0
+        "y": 3
       },
       "id": 18,
       "options": {
@@ -215,7 +248,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 0
+        "y": 3
       },
       "id": 16,
       "interval": "1h",
@@ -325,7 +358,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 0
+        "y": 3
       },
       "id": 19,
       "interval": "1h",
@@ -523,7 +556,7 @@
         "h": 9,
         "w": 15,
         "x": 9,
-        "y": 4
+        "y": 7
       },
       "id": 2,
       "interval": "60s",
@@ -575,7 +608,7 @@
         "h": 16,
         "w": 9,
         "x": 0,
-        "y": 6
+        "y": 9
       },
       "id": 6,
       "options": {
@@ -648,8 +681,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-green",
-                "value": null
+                "color": "light-green"
               }
             ]
           },
@@ -716,7 +748,7 @@
         "h": 9,
         "w": 15,
         "x": 9,
-        "y": 13
+        "y": 16
       },
       "id": 9,
       "interval": "60s",
@@ -764,6 +796,6 @@
   "timezone": "",
   "title": "wis2downloader dashboard",
   "uid": "zB4GjVaIk",
-  "version": 5,
+  "version": 1,
   "weekStart": ""
 }

--- a/grafana/dashboards/wis2downloader.json
+++ b/grafana/dashboards/wis2downloader.json
@@ -24,43 +24,10 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 2,
   "links": [],
   "liveNow": false,
   "panels": [
-    {
-      "datasource": {
-        "type": "datasource",
-        "uid": "grafana"
-      },
-      "description": "show all the alerting alert",
-      "gridPos": {
-        "h": 3,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 21,
-      "options": {
-        "alertName": "",
-        "dashboardAlerts": false,
-        "dashboardTitle": "",
-        "maxItems": 10,
-        "showOptions": "current",
-        "sortOrder": 1,
-        "stateFilter": {
-          "alerting": true,
-          "execution_error": false,
-          "no_data": false,
-          "ok": false,
-          "paused": false,
-          "pending": false
-        },
-        "tags": []
-      },
-      "pluginVersion": "",
-      "title": "Current Alerts Overview",
-      "type": "alertlist"
-    },
     {
       "datasource": {
         "type": "prometheus",
@@ -94,7 +61,7 @@
         "h": 6,
         "w": 9,
         "x": 0,
-        "y": 3
+        "y": 0
       },
       "id": 14,
       "options": {
@@ -113,7 +80,7 @@
           }
         ]
       },
-      "pluginVersion": "",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
           "datasource": {
@@ -181,7 +148,7 @@
         "h": 4,
         "w": 3,
         "x": 9,
-        "y": 3
+        "y": 0
       },
       "id": 18,
       "options": {
@@ -196,7 +163,7 @@
         "showThresholdLabels": false,
         "showThresholdMarkers": true
       },
-      "pluginVersion": "",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
           "datasource": {
@@ -248,7 +215,7 @@
         "h": 4,
         "w": 6,
         "x": 12,
-        "y": 3
+        "y": 0
       },
       "id": 16,
       "interval": "1h",
@@ -270,7 +237,7 @@
           "valueSize": 20
         }
       },
-      "pluginVersion": "",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
           "datasource": {
@@ -358,7 +325,7 @@
         "h": 4,
         "w": 6,
         "x": 18,
-        "y": 3
+        "y": 0
       },
       "id": 19,
       "interval": "1h",
@@ -380,7 +347,7 @@
           "valueSize": 20
         }
       },
-      "pluginVersion": "",
+      "pluginVersion": "9.0.3",
       "targets": [
         {
           "datasource": {
@@ -556,7 +523,7 @@
         "h": 9,
         "w": 15,
         "x": 9,
-        "y": 7
+        "y": 4
       },
       "id": 2,
       "interval": "60s",
@@ -608,7 +575,7 @@
         "h": 16,
         "w": 9,
         "x": 0,
-        "y": 9
+        "y": 6
       },
       "id": 6,
       "options": {
@@ -681,7 +648,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-green"
+                "color": "light-green",
+                "value": null
               }
             ]
           },
@@ -748,7 +716,7 @@
         "h": 9,
         "w": 15,
         "x": 9,
-        "y": 16
+        "y": 13
       },
       "id": 9,
       "interval": "60s",

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -8,9 +8,9 @@ global:
 alerting:
   alertmanagers:
   - static_configs:
-    - targets: 
+    - targets:
       # - alertmanager:9093
-  
+
 scrape_configs:
 - job_name: minio-job
   metrics_path: /minio/v2/metrics/cluster

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -8,7 +8,8 @@ global:
 alerting:
   alertmanagers:
   - static_configs:
-    - targets: []
+    - targets: 
+      # - alertmanager:9093
   
 scrape_configs:
 - job_name: minio-job

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -8,26 +8,33 @@ global:
 alerting:
   alertmanagers:
   - static_configs:
-    - targets:
-      # - alertmanager:9093
-
+    - targets: []
+  
 scrape_configs:
 - job_name: minio-job
   metrics_path: /minio/v2/metrics/cluster
   scheme: http
   static_configs:
   - targets: ['minio:9000']
+
 - job_name: 'mqtt_metrics_collector'
   scrape_interval: 5s
   static_configs:
   - targets: ['mqtt_metrics_collector:8001']
+
 - job_name: 'cadvisor'
   static_configs:
   - targets: ['cadvisor:8080']
     labels:
       alias: 'cadvisor'
+
 - job_name: wis2downloader
   metrics_path: /metrics
   scheme: http
   static_configs:
   - targets: ['wis2downloader:5000']
+
+- job_name: 'elasticsearch-exporter'
+  scrape_interval: 15s
+  static_configs:
+  - targets: ['elasticsearch-exporter:9114']


### PR DESCRIPTION
Fix issue 674:
Add new dashboard to monitor the health of elasticsearch:

Alert List Panel:
This panel provides an overview of current alerts, specifically those in the "alerting" state, with a maximum of 10 alerts displayed.

Elasticsearch Disk Space Utilization Panel:
Monitors the percentage of disk space used in the Elasticsearch cluster (es-wis2box).
Alerts trigger if disk usage exceeds 90%, with thresholds visually represented by color codes (green, yellow, dark red).

Elasticsearch Available Disk Space Panel:
Displays the total amount of free disk space across all nodes in the cluster.
Alerts trigger if available disk space drops below 10 GB, with similar color-coded thresholds.
Alerting Configuration:

High Storage Usage Alert:
Triggers when disk space usage exceeds 90% for more than 5 minutes.
Configured to send notifications to a specified channel or recipient.

Low Free Disk Space Alert:
Activates if the free disk space falls below 10 GB for more than 5 minutes.
The alert also uses a threshold-based color system to visually indicate critical conditions.
<img width="480" alt="9de71c1a-cc5e-48ef-9b41-fe40110a193a" src="https://github.com/user-attachments/assets/3bd210ba-47e0-4753-8a20-f276f3abb1b7">
