### PR TITLE
loki-fix

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -30,6 +30,10 @@ services:
     volumes:
       - loki-data:/loki
       - ./loki/loki-config.yml:/etc/loki/loki-config.yml
+    networks:
+      vpcbr: # this is the place where we assign the static ipv4 address
+        ipv4_address: 10.5.0.2
+      default:
 
   # mqtt_metrics_collector, listens to mqtt-broker
   mqtt_metrics_collector:
@@ -106,6 +110,7 @@ services:
   # Elasticsearch Exporter for monitoring Elasticsearch metrics
   elasticsearch-exporter:
     <<: *logging
+    container_name: elasticsearch-exporter
     image: quay.io/prometheuscommunity/elasticsearch-exporter:latest
     command:
       - '--es.uri=http://elasticsearch:9200'


### PR DESCRIPTION
I found https://github.com/wmo-im/wis2box/pull/729 broke loki since the loki-network configuration was deleted, this PR puts the missing loki-configuration back.

I also explicitly named the elasticsearch-exporter container