### PR TITLE
improved monitoring stack

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -63,6 +63,7 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.retention.time=10d'
+      - '--log.level=warn'
 
   # uncomment cadvisor to monitor containers
   # cadvisor:
@@ -104,6 +105,8 @@ services:
       - GF_DISABLE_SIGNOUT_MENU=true
       - GF_SERVER_ROOT_URL=${WIS2BOX_URL:-http://localhost}/monitoring
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
+      - GF_USAGE_STATS_ENABLED=false
+      - GF_LOG_LEVEL=warn
     ports:
       - 3000:3000
 

--- a/loki/loki-config.yml
+++ b/loki/loki-config.yml
@@ -2,6 +2,7 @@ auth_enabled: false
 
 server:
   http_listen_port: 3100
+  log_level: warn
 
 common:
   path_prefix: /loki
@@ -25,8 +26,14 @@ schema_config:
         prefix: index_
         period: 24h
 
-table_manager:
-  retention_deletes_enabled: true
+compactor:
+  working_directory: /loki/retention
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 5m
+  retention_delete_worker_count: 5
+
+limits_config:
   retention_period: 240h
 
 ruler:


### PR DESCRIPTION
I have noted that the disk usage over time is related due to the loki log retention not kicking in and excessive logging  (info vs warning) by grafana/prometheus/loki containers. I started this PR to apply some fixes to reduce the burden of the monitoring-stack on the host-system !