### PR TITLE
metadata for data-centric api

### DIFF
--- a/wis2box-management/wis2box/data/bufr4.py
+++ b/wis2box-management/wis2box/data/bufr4.py
@@ -54,6 +54,7 @@ class ObservationDataBUFR(BaseAbstractData):
         payload = {
             'inputs': {
                 'channel': self.topic_hierarchy.replace('origin/a/wis2/', ''),
+                'metadata_id': self.metadata_id,
                 'notify': False,
                 'data': data
             }

--- a/wis2box-management/wis2box/data/csv2bufr.py
+++ b/wis2box-management/wis2box/data/csv2bufr.py
@@ -66,6 +66,7 @@ class ObservationDataCSV2BUFR(BaseAbstractData):
         payload = {
             'inputs': {
                 'channel': self.topic_hierarchy.replace('origin/a/wis2/', ''),
+                'metadata_id': self.metadata_id,
                 'template': self.template,
                 'notify': False,
                 'data': data

--- a/wis2box-management/wis2box/data/synop2bufr.py
+++ b/wis2box-management/wis2box/data/synop2bufr.py
@@ -76,6 +76,7 @@ class ObservationDataSYNOP2BUFR(BaseAbstractData):
         payload = {
             'inputs': {
                 'channel': self.topic_hierarchy.replace('origin/a/wis2/', ''),
+                'metadata_id': self.metadata_id,
                 'year': year,
                 'month': month,
                 'notify': False,


### PR DESCRIPTION
to support the datacentric approach, the api-functions now require to receive a metadata_id