### PR TITLE
wis2downloader removed from image build workflow

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -30,7 +30,6 @@ jobs:
           - wis2box-broker
           - wis2box-management
           - wis2box-mqtt-metrics-collector
-          - wis2downloader
           # - wis2box-ui
 
 


### PR DESCRIPTION
wis2downloader removed from list of images to build, now built and published externally. This should fix the related error in the publish image workflow.