### PR TITLE
to deal with first label in metric

### DIFF
--- a/wis2box-mqtt-metrics-collector/mqtt_metrics_collector.py
+++ b/wis2box-mqtt-metrics-collector/mqtt_metrics_collector.py
@@ -29,6 +29,7 @@ import random
 
 import sys
 import json
+import time
 
 from prometheus_client import start_http_server, Counter, Gauge
 
@@ -166,6 +167,12 @@ def sub_mqtt_metrics(client, userdata, msg):
         wsi = 'none'
         if 'wigos_station_identifier' in m['properties']:
             wsi = m['properties']['wigos_station_identifier']
+        # if label wsi is not present in notify_wsi_total, set it to 0 and sleep 5 seconds before incrementing
+        if wsi not in notify_wsi_total._metrics:
+            notify_wsi_total.labels(wsi).inc(0)
+            failure_wsi_total.labels(wsi).inc(0)
+            station_wsi.labels(wsi).set(1)
+            time.sleep(5)
         notify_wsi_total.labels(wsi).inc(1)
         failure_wsi_total.labels(wsi).inc(0)
         station_wsi.labels(wsi).set(1)

--- a/wis2box-mqtt-metrics-collector/mqtt_metrics_collector.py
+++ b/wis2box-mqtt-metrics-collector/mqtt_metrics_collector.py
@@ -167,8 +167,9 @@ def sub_mqtt_metrics(client, userdata, msg):
         wsi = 'none'
         if 'wigos_station_identifier' in m['properties']:
             wsi = m['properties']['wigos_station_identifier']
-        # if label wsi is not present in notify_wsi_total, set it to 0 and sleep 5 seconds before incrementing
+        # if label wsi is not in notify_wsi_total, set to 0 and sleep 5s
         if wsi not in notify_wsi_total._metrics:
+            logger.info(f"new station: {wsi}, sleep 5s before incrementing")
             notify_wsi_total.labels(wsi).inc(0)
             failure_wsi_total.labels(wsi).inc(0)
             station_wsi.labels(wsi).set(1)


### PR DESCRIPTION
When monitoring the increase of a metric using prometheus-query, the first entry for a label is not detected since increase() can only detect the difference between 2-scrapes. This is a minor issue that only affects the first time a label is created but it is a bit confusing for training when we always start with a brand new instance.

This PR fixes this by waiting 5 seconds (scrape interval) for a new label-entry in a metric.