### PR TITLE
update GRIB/BUFR media types

### DIFF
--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -345,7 +345,7 @@ def test_message_api():
 
     link_rel = msg['links'][0]
 
-    assert link_rel['type'] == 'application/x-bufr'
+    assert link_rel['type'] == 'application/bufr'
 
     r = SESSION.get(link_rel['href'])
 
@@ -387,6 +387,6 @@ def test_message_api():
 
     link_rel = msg['links'][0]
 
-    assert link_rel['type'] == 'application/x-bufr'
+    assert link_rel['type'] == 'application/bufr'
     assert link_rel['security']['default']['type'] == 'http'
     assert link_rel['security']['default']['scheme'] == 'bearer'

--- a/wis2box-management/wis2box/pubsub/message.py
+++ b/wis2box-management/wis2box/pubsub/message.py
@@ -44,8 +44,8 @@ class SecureHashAlgorithms(Enum):
 
 
 DATA_OBJECT_MIMETYPES = {
-    'bufr4': 'application/x-bufr',
-    'grib2': 'application/x-grib2',
+    'bufr4': 'application/bufr',
+    'grib2': 'application/grib2',
     'geojson': 'application/json'
 }
 
@@ -183,7 +183,7 @@ class WISNotificationMessage(PubSubMessage):
                 }
             },
             'links': links,
-            'generated-by': f'wis2box {__version__}'
+            'generated_by': f'wis2box {__version__}'
         }
 
         if metadata_id is not None:


### PR DESCRIPTION
- update GRIB/BUFR media types given they are now approved by IANA
- update `generated_by` for consistency with other tools such as pywcmp