### PR TITLE
fix extract images version

### DIFF
--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -280,7 +280,7 @@ def update_images_yml() -> str:
     # find currently used version of docker-compose.images-*.yml
     for file in os.listdir('.'):
         if file.startswith('docker-compose.images-') and file.endswith('.yml'):
-            current_version = file.split('-')[2].split('.')[0]
+            current_version = file.split('images-')[1].split('.yml')[0]
 
     if current_version == version:
         print(f'Using latest version {version}, no update of images file required')


### PR DESCRIPTION
The current version is incorrectly extracted:
```
python3 wis2box-ctl.py update --restart
Current version=1, latest version=1.0.0rc1
Would you like to update ? (y/n/exit)
```

this PR will fix this:

```
python3 wis2box-ctl.py update --restart
Using latest version 1.0.0rc1, no update of images file required
```