### PR TITLE
pubTime should be pubtime

### DIFF
--- a/wis2box-management/wis2box/api/backend/elastic.py
+++ b/wis2box-management/wis2box/api/backend/elastic.py
@@ -69,7 +69,7 @@ MAPPINGS = {
                         }
                     }
                 },
-                'pubTime': {
+                'pubtime': {
                     'type': 'date',
                     'fields': {
                         'raw': {
@@ -416,8 +416,8 @@ class ElasticBackend(BaseBackend):
             'query': {
                 'bool': {
                     'should': [
-                        {'range': {'properties.pubTime': {'lte': before}}},
-                        {'range': {'properties.pubTime': {'gte': after}}}
+                        {'range': {'properties.pubtime': {'lte': before}}},
+                        {'range': {'properties.pubtime': {'gte': after}}}
                     ]
                 }
             }


### PR DESCRIPTION
To resolve the issue reported in https://github.com/World-Meteorological-Organization/wis2box/issues/1037 by @davidpodeur

The command wis2box api clean was not deleting any records for the "messages"-collection due to an issue in the spelling of the attribute in the elasticsearch-record: pubTime should be pubtime