### PR TITLE
issue#1043-Grafana 12 alerting/permissions modification

### DIFF
--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -101,7 +101,7 @@ services:
       - GF_UNIFIED_ALERTING_ENABLED=true
       - GF_USERS_DEFAULT_THEME=dark
       - GF_DISABLE_SIGNOUT_MENU=true
-      - GF_SERVER_ROOT_URL=${WIS2BOX_URL}:3000/monitoring
+      - GF_SERVER_ROOT_URL=http://localhost:3000
       - GF_SERVER_SERVE_FROM_SUB_PATH=true
       - GF_USAGE_STATS_ENABLED=false
       - GF_LOG_LEVEL=warn


### PR DESCRIPTION
I tested upgrading Grafana from 9.0.3 to 12.3.2 in the wis2box monitoring stack.

Regarding the findings mentioned in issue #1043 (https://github.com/World-Meteorological-Organization/wis2box/issues/1043):

1. Alert panel permission issue:

The Permission required message in the Current Alerts Overview panel is related to Grafana alerting permissions.

It was resolved by enabling unified alerting and allowing anonymous users to read alert rules.

Before:
<img width="1440" height="775" alt="Screenshot 2026-03-10 at 11 00 58" src="https://github.com/user-attachments/assets/ea0b1809-2fe2-40f8-89db-13dbab88023c" />
After:
<img width="1437" height="778" alt="Screenshot 2026-03-10 at 10 57 55" src="https://github.com/user-attachments/assets/7f1e298e-2e4b-43db-aff5-ebaa753e2079" />

2. Access URL:

Accessing localhost:3000 redirects to localhost.
The correct URL to access Grafana is localhost:3000/monitoring.
I checked the configuration this behavior is related to the current configuration which is unrelated to Grafana upgrading:

Here:
GF_SERVER_ROOT_URL=${WIS2BOX_URL:-http://localhost}/monitoring
GF_SERVER_SERVE_FROM_SUB_PATH=true

Since the default root_url does not include port 3000, Grafana generates redirects to http://localhost/monitoring. But if needed, this could be adjusted by including port 3000 in the default value.

3. Station data publishing status

The Station data publishing status panel is working correctly. The values appear as 0 because no station data had been published yet during testing.

Conclusion

Grafana 12.3.2 appears compatible with wis2box, with only minor configuration adjustments required (Permissions).