### PR TITLE
bump pygeometa to 0.21.0

### DIFF
--- a/examples/config/surface-weather-observations.yml
+++ b/examples/config/surface-weather-observations.yml
@@ -5,22 +5,22 @@ wis2box:
     centre_id: centre_id
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:centre_id:surface-weather-observations
     language: en
     charset: utf8
     hierarchylevel: dataset
+    dates:
+        creation: 2021-11-29
+        publication: 2021-11-29
 
 identification:
     language: en
     charset: utf8
     title: Surface weather observations from centre_id
     abstract: Surface weather observations from centre_id
-    dates:
-        creation: 2021-11-29
-        publication: 2021-11-29
     keywords:
         default:
             keywords:
@@ -36,7 +36,7 @@ identification:
                 url: https://codes.wmo.int/topic-hierarchy/earth-system-discipline
     extents:
         spatial:
-            - bbox: [-180, -90, 190, 90]
+            - bbox: [-180, -90, 180, 90]
               crs: 4326
         temporal:
             - begin: 2021-11-29

--- a/tests/data/metadata/discovery/ca-annual-min-max-daily-water-flow-mcf1.yml
+++ b/tests/data/metadata/discovery/ca-annual-min-max-daily-water-flow-mcf1.yml
@@ -1,0 +1,69 @@
+wis2box:
+    country: can
+    centre_id: ca-eccc-msc-test
+    data_mappings:
+        plugins:
+
+mcf:
+    version: 1.0
+
+metadata:
+    identifier: urn:wmo:md:ca-eccc-msc-test:daily-water-flow
+    hierarchylevel: dataset
+
+identification:
+    title: Annual Maximum and Minimum Daily Water Level or Flow
+    abstract: The annual maximum and minimum daily data are the maximum and minimum daily mean values for a given year.
+    dates:
+        creation: 1850-01-01
+    keywords:
+        default:
+            keywords:
+                - Historical
+                - Archive
+                - Hydrology
+                - Hydrometric
+                - Streamflow
+                - Discharge
+                - Water level
+                - Water quantiy
+                - Sediment concentration
+                - Water
+                - National (CA)
+                - Observation
+                - Measurement
+        wmo:
+            keywords:
+                - hydrology
+            keywords_type: theme
+            vocabulary:
+                name: Earth system disciplines as defined by the WMO Unified Data Policy, Resolution 1 (Cg-Ext(2021), Annex 1.
+                url:  https://codes.wmo.int/wis/topic-hierarchy/earth-system-discipline
+    extents:
+        spatial:
+            - bbox: [20.2201924985,43.6884447292,29.62654341,48.2208812526]
+              crs: 4326
+        temporal:
+            - begin: 2023-01-17
+              end: null
+              resolution: PT24H
+    url: 
+        - https://api.weather.gc.ca/collections/hydrometric-annual-statistics/items
+
+    wmo_data_policy: core
+
+contact:
+    host:
+        organization: Government of Canada; Environment and Climate Change Canada; Meteorological Service of Canada
+        url: https://www.canada.ca/en/environment-climate-change.html
+        country: Canada
+        email: you@example.org
+        hoursofservice: 0700h - 1500h UTC
+        contactinstructions: email
+
+distribution:
+    items:
+        url: https://api.weather.gc.ca/collections/hydrometric-annual-statistics/items
+        type: application/geo+json
+        rel: items
+        description: hydrometric-annual-statistics

--- a/tests/data/metadata/discovery/ca-annual-min-max-daily-water-flow.yml
+++ b/tests/data/metadata/discovery/ca-annual-min-max-daily-water-flow.yml
@@ -5,17 +5,17 @@ wis2box:
         plugins:
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:ca-eccc-msc-test:daily-water-flow
     hierarchylevel: dataset
+    dates:
+        creation: 1850-01-01
 
 identification:
     title: Annual Maximum and Minimum Daily Water Level or Flow
     abstract: The annual maximum and minimum daily data are the maximum and minimum daily mean values for a given year.
-    dates:
-        creation: 1850-01-01
     keywords:
         default:
             keywords:
@@ -26,7 +26,7 @@ identification:
                 - Streamflow
                 - Discharge
                 - Water level
-                - Water quantiy
+                - Water quantity
                 - Sediment concentration
                 - Water
                 - National (CA)

--- a/tests/data/metadata/discovery/cd-surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/cd-surface-weather-observations.yml
@@ -16,17 +16,17 @@ wis2box:
                   file-pattern: '^.*\.bufr4$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:cg-met:surface-weather-observations
     hierarchylevel: dataset
+    dates:
+        creation: 2023-03-26
 
 identification:
     title: Surface weather observations from Republic of Congo
     abstract: Surface weather observations from Republic of Congo
-    dates:
-        creation: 2023-03-26
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/cn-grapes-geps-global.yml
+++ b/tests/data/metadata/discovery/cn-grapes-geps-global.yml
@@ -14,17 +14,17 @@ wis2box:
                   file-pattern: '^.*_(\d{8})\d{2}.*\.grib2$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:cn-cma:grapes-geps-global
     hierarchylevel: dataset
+    dates:
+        creation: 2024-01-17
 
 identification:
     title: CMA GRAPES GEPS v1.3
     abstract: GRAPES GEPS is the main technical means to solve the uncertainty of CMA-GFS medium-term forecast and the difficulties of extreme weather forecast.
-    dates:
-        creation: 2024-01-17
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/dz-surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/dz-surface-weather-observations.yml
@@ -17,17 +17,17 @@ wis2box:
                   file-pattern: '^WIGOS_(\d-\d+-\d+-\w+)_.*\.bufr4$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:dz-meteoalgerie:surface-weather-observations
     hierarchylevel: dataset
+    dates:
+        creation: 2021-11-29
 
 identification:
     title: Surface weather observations from Algeria
     abstract: Surface weather observations from Algeria
-    dates:
-        creation: 2021-11-29
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/int-wmo-test-cap.yml
+++ b/tests/data/metadata/discovery/int-wmo-test-cap.yml
@@ -12,17 +12,17 @@ wis2box:
                   file-pattern: '^.*\.xml$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:int-wmo-test:cap
     hierarchylevel: dataset
+    dates:
+        creation: 2023-03-26
 
 identification:
     title: CAP Alerts test dataset
     abstract: CAP Alerts test dataset
-    dates:
-        creation: 2023-03-26
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/int-wmo-test-drifting-buoys.yml
+++ b/tests/data/metadata/discovery/int-wmo-test-drifting-buoys.yml
@@ -13,17 +13,17 @@ wis2box:
                 file-pattern: '^A_[A-Z0-9]{6}.*_._[A-Z]{4}_(\d{4}\d{2}\d{2}).*\.bin$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:int-wmo-test:surface-weather-observations:drifting-buoys
     hierarchylevel: dataset
+    dates:
+        creation: 2024-02-16
 
 identification:
     title: Example surface observations from GOOS drifting buoy networks
     abstract: Surface observations from GOOS drifting buoy networks downloaded from the WIS.
-    dates:
-        creation: 2024-02-16
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/int-wmo-test-ship.yml
+++ b/tests/data/metadata/discovery/int-wmo-test-ship.yml
@@ -13,17 +13,17 @@ wis2box:
                   file-pattern: '^A_[A-Z0-9]{6}.*_._[A-Z]{4}_(\d{4}\d{2}\d{2}).*\.bin$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:int-wmo-test:surface-weather-observations:ship
     hierarchylevel: dataset
+    dates:
+        creation: 2024-03-04
 
 identification:
     title: Example surface weather observations GOOS Voluntary Observing Ships
     abstract: Example surface weather observations from GOOS Voluntary Observing Ships downloaded from the WIS.
-    dates:
-        creation: 2024-03-04
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/int-wmo-test-wind-profile.yml
+++ b/tests/data/metadata/discovery/int-wmo-test-wind-profile.yml
@@ -13,17 +13,17 @@ wis2box:
                   file-pattern: '^WIGOS_\d-\d+-\d+-\w+_(\d{4}\d{2}\d{2}).*\.bin$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:int-wmo-test:surface-weather-observations:wind-profile
     hierarchylevel: dataset
+    dates:
+        creation: 2024-03-01
 
 identification:
     title: Example wind profiler data from Singapore
     abstract: Example wind profiler data from Singapore downloaded from WIS2.0.
-    dates:
-        creation: 2024-03-01
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/it-surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/it-surface-weather-observations.yml
@@ -14,17 +14,17 @@ wis2box:
                   file-pattern: '^WIGOS_(\d-\d+-\d+-\w+)_.*\.bufr4$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:it-meteoam:surface-weather-observations
     hierarchylevel: dataset
+    dates:
+        creation: 2021-11-29
 
 identification:
     title: Surface weather observations from Italy
     abstract: Surface weather observations from Italy
-    dates:
-        creation: 2021-11-29
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/mw-surface-weather-observations.yml
+++ b/tests/data/metadata/discovery/mw-surface-weather-observations.yml
@@ -15,17 +15,17 @@ wis2box:
                   file-pattern: '^WIGOS_(\d-\d+-\d+-\w+)_.*\.bufr4$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:mw-mw_met_centre-test:surface-weather-observations
     hierarchylevel: dataset
+    dates:
+        creation: 2021-11-29
 
 identification:
     title: Surface weather observations from Malawi
     abstract: Surface weather observations from Malawi
-    dates:
-        creation: 2021-11-29
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/org-daycli-test.yml
+++ b/tests/data/metadata/discovery/org-daycli-test.yml
@@ -15,17 +15,17 @@ wis2box:
                   file-pattern: '^WIGOS_(\d-\d+-\d+-\w+)_.*\.bufr4$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:org-daycli-test:surface-climate-observations:daily
     hierarchylevel: dataset
+    dates:
+        creation: 2024-03-04
 
 identification:
     title: Daily values from land stations (DAYCLI) 
     abstract: Daily values from land stations (DAYCLI)
-    dates:
-        creation: 2024-03-04
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/ro-synoptic-weather-observations.yml
+++ b/tests/data/metadata/discovery/ro-synoptic-weather-observations.yml
@@ -16,17 +16,17 @@ wis2box:
                   file-pattern: '^.*\.csv$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:ro-rnimh-test:synoptic-weather-observations
     hierarchylevel: dataset
+    dates:
+        creation: 2023-01-18
 
 identification:
     title: Synoptic weather observations from Romania
     abstract: Synoptic weather observations from Romania
-    dates:
-        creation: 2023-01-18
     keywords:
         default:
             keywords:

--- a/tests/data/metadata/discovery/unpublish-test.yml
+++ b/tests/data/metadata/discovery/unpublish-test.yml
@@ -12,17 +12,17 @@ wis2box:
                   file-pattern: '^.*_(\d{8})\d{2}.*\.grib2$'
 
 mcf:
-    version: 1.0
+    version: 2.0
 
 metadata:
     identifier: urn:wmo:md:unpublish-test:deleteme
     hierarchylevel: dataset
+    dates:
+        creation: 2025-08-06
 
 identification:
     title: deleteme test dataset
     abstract: This dataset is used to test the unpublish functionality of WIS2Box.
-    dates:
-        creation: 2025-08-06
     keywords:
         default:
             keywords:

--- a/wis2box-management/Dockerfile
+++ b/wis2box-management/Dockerfile
@@ -68,7 +68,7 @@ RUN cd /app \
     && $PIP_PLUGIN_PACKAGES \
     && pip3 install --no-cache-dir \
     https://github.com/wmo-cop/pyoscar/archive/refs/tags/0.9.0.zip \
-    https://github.com/geopython/pygeometa/archive/refs/tags/0.16.0.zip \
+    https://github.com/geopython/pygeometa/archive/refs/tags/0.21.1.zip \
     https://github.com/World-Meteorological-Organization/pywis-topics/archive/refs/tags/0.3.5.zip \
     && pip3 install --no-cache-dir capvalidator==0.1.0-dev4 cython shapely botocore boto3 \
     && pip3 install --force-reinstall numpy==2.3.5

--- a/wis2box-management/wis2box/metadata/discovery.py
+++ b/wis2box-management/wis2box/metadata/discovery.py
@@ -77,7 +77,7 @@ class DiscoveryMetadata(BaseMetadata):
             md['identification']['wmo_data_policy'] = mqtt_topic.split('/')[5]
 
         LOGGER.debug('Adding revision date')
-        md['identification']['dates']['revision'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
+        md['metadata']['dates']['revision'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')  # noqa
 
         LOGGER.debug('Checking temporal extents')
         if md['identification']['extents']['temporal'][0].get('begin', 'BEGIN_DATE') is None:  # noqa


### PR DESCRIPTION
This PR updates pygeometa support to 0.21.0 (https://github.com/geopython/pygeometa/releases/tag/0.21.0), which includes breaking changes for the MCF format.