### PR TITLE
Add easy-to-use option to add Traefik to wis2box-stack to enable SSL and automated certificate renewal

### DIFF
--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,0 +1,32 @@
+services:
+  web-proxy:
+    ports:
+    - 8000:80
+    volumes:
+      - ./nginx/nginx-ssl.conf:/etc/nginx/conf.d/ssl.conf
+    labels:
+    - "traefik.enable=true"
+    - "traefik.http.routers.wis2box.rule=Host(`${WIS2BOX_HOST}`)"
+    - "traefik.http.routers.wis2box.entrypoints=websecure"
+    - "traefik.http.routers.wis2box.tls.certresolver=myresolver"
+    - "traefik.http.services.wis2box.loadbalancer.server.port=8080"
+    
+  traefik:
+    image: traefik:v2.11
+    restart: unless-stopped
+    command:
+      - --api.insecure=true
+      - --certificatesresolvers.myresolver.acme.tlschallenge=true
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --providers.docker=true
+      - --certificatesresolvers.myresolver.acme.storage=/letsencrypt/acme.json
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - traefik-letsencrypt:/letsencrypt
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+volumes:
+  traefik-letsencrypt:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -8,6 +8,7 @@ services:
     - "traefik.http.services.wis2box.loadbalancer.server.port=80"
     
   traefik:
+    container_name: traefik
     image: traefik:v2.11
     restart: unless-stopped
     command:

--- a/docker-compose.traefik.yml
+++ b/docker-compose.traefik.yml
@@ -1,15 +1,11 @@
 services:
   web-proxy:
-    ports:
-    - 8000:80
-    volumes:
-      - ./nginx/nginx-ssl.conf:/etc/nginx/conf.d/ssl.conf
     labels:
     - "traefik.enable=true"
     - "traefik.http.routers.wis2box.rule=Host(`${WIS2BOX_HOST}`)"
     - "traefik.http.routers.wis2box.entrypoints=websecure"
     - "traefik.http.routers.wis2box.tls.certresolver=myresolver"
-    - "traefik.http.services.wis2box.loadbalancer.server.port=8080"
+    - "traefik.http.services.wis2box.loadbalancer.server.port=80"
     
   traefik:
     image: traefik:v2.11
@@ -27,6 +23,15 @@ services:
     volumes:
       - traefik-letsencrypt:/letsencrypt
       - /var/run/docker.sock:/var/run/docker.sock:ro
+
+  minio:
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+  mosquitto:
+    ports:
+      - 1883:1883
 
 volumes:
   traefik-letsencrypt:

--- a/docs/source/user/public-services-setup.rst
+++ b/docs/source/user/public-services-setup.rst
@@ -47,13 +47,8 @@ web-proxy (nginx)
 
 wis2box runs a local nginx container allowing access to the following HTTP-based services. You can expose these services securely using SSL in two ways:
 
-1. **Using Traefik with Let's Encrypt (from wis2box-1.3)**
 
-  wis2box supports running a Traefik reverse proxy that can automatically provision and renew SSL certificates from Let's Encrypt for your public services. When Traefik is enabled, it will handle all HTTPS traffic and certificate renewals automatically, so you do not need to manually manage certificates. This is the recommended approach for most users.
-
-2. **Manual SSL with nginx**
-
-  You can enable SSL by setting the ``WIS2BOX_SSL_CERT`` and ``WIS2BOX_SSL_KEY`` environment variables to the location of your SSL certificate and private key, respectively. In this case, you are responsible for providing valid certificates and ensuring they are renewed before expiration. When SSL is enabled this way, nginx will serve HTTPS using the configuration defined in ``nginx/nginx-ssl.conf``.
+For details on enabling SSL (using Traefik with Let's Encrypt or manual SSL with nginx), see the :ref:`ssl-setup` section below.
 
 The following HTTP-based services are available:
 
@@ -186,9 +181,9 @@ The mosquitto service within wis2box also has websockets enabled and is proxied 
 The broker address for the Global Broker to subscribe to WIS2 notifications using the mosquitto service within wis2box is as follows:
 
 - `mqtt://everyone:everyone@WIS2BOX_HOST:1883` - for MQTT without SSL
-- `mqtts://everyone:everyone@WIS2BOX_HOST:8883` - for MQTT with SSL
+- `mqtts://everyone:everyone@WIS2BOX_HOST:8883` - for MQTT with SSL (only when WIS2BOX_SSL_CERT and WIS2BOX_SSL_KEY are set)
 - `ws://everyone:everyone@WIS2BOX_HOST/mqtt:80` - for MQTT over websockets without SSL
-- `wss://everyone:everyone@WIS2BOX_HOST/mqtt:443` - for MQTT over websockets with SSL
+- `wss://everyone:everyone@WIS2BOX_HOST/mqtt:443` - for MQTT over websockets with SSL (recommended when SSL is enabled using Traefik)
 
 Where ``WIS2BOX_HOST`` is the hostname or IP address of the host running wis2box.
 
@@ -233,17 +228,37 @@ If you do not wish to expose the internal MQTT broker on wis2box, you can config
 
    The ``everyone`` user is defined by default for public readonly access (``origin/#``) as per WIS2 Node requirements.
 
+
+.. _ssl-setup:
+
+
 SSL
 ^^^
 
-In order to ensure the security of your data, it is recommended to enable SSL on your wis2box instance.
+To ensure the security of your data, it is recommended to enable SSL for your wis2box instance. 
+There are two main approaches to enable SSL on the HTTP services of your wis2box instance:
 
-There are multiple ways to expose the wis2box services over SSL:
+**1. External SSL Termination**
 
-- using a reverse proxy (recommended)
-- using the built-in SSL support in the ``wis2box-ctl.py`` script
+Use a reverse proxy (such as nginx, Traefik, or a load balancer) outside of the wis2box-instance to terminate SSL and forward traffic to
+ wis2box over HTTP. This way certificate management and encryption is handled outside of wis2box. 
+Check with your IT department or hosting provider for your options for setting up external SSL termination.
 
-The recommended way to expose the wis2box services over SSL is to use a reverse proxy such as `nginx`_ or `traefik`_. Discuss with your IT team to determine which reverse proxy is best suited for your environment.
+**2. Internal SSL Termination (SSL handled by wis2box)**
+
+If you prefer wis2box to handle SSL termination directly, you have two options:
+
+  a. **Traefik with Let's Encrypt (from wis2box-1.3):**
+     wis2box can run a Traefik reverse proxy that automatically provisions and renews SSL certificates from Let's Encrypt for your public services. When Traefik is enabled, it manages all HTTPS traffic and certificate renewals automatically.
+     To enable Traefik you can use the file 'docker-compose.traefik.yml' included in the wis2box repository, and use it replace the default 'docker-compose.override.yml' file as follows:
+     
+     .. code-block:: bash
+
+        cp docker-compose.traefik.yml docker-compose.override.yml
+
+  b. **Manual SSL with nginx:**
+     You can enable SSL by setting the ``WIS2BOX_SSL_CERT`` and ``WIS2BOX_SSL_KEY`` environment variables to the location of your SSL certificate and private key, respectively.
+     In this case, you are responsible for providing valid certificates and ensuring they are renewed before expiration. When SSL is enabled this way, nginx will serve HTTPS using the configuration defined in ``nginx/nginx-ssl.conf``.
 
 Please remember to update the ``WIS2BOX_URL`` and ``WIS2BOX_API_URL`` environment variable after enabling SSL, ensuring your URL starts with ``https://``.
 

--- a/docs/source/user/public-services-setup.rst
+++ b/docs/source/user/public-services-setup.rst
@@ -45,7 +45,17 @@ The next sections describe the public services available in wis2box and how to c
 web-proxy (nginx)
 ^^^^^^^^^^^^^^^^^
 
-wis2box runs a local nginx container allowing access to the following HTTP based services:
+wis2box runs a local nginx container allowing access to the following HTTP-based services. You can expose these services securely using SSL in two ways:
+
+1. **Using Traefik with Let's Encrypt (from wis2box-1.3)**
+
+  wis2box supports running a Traefik reverse proxy that can automatically provision and renew SSL certificates from Let's Encrypt for your public services. When Traefik is enabled, it will handle all HTTPS traffic and certificate renewals automatically, so you do not need to manually manage certificates. This is the recommended approach for most users.
+
+2. **Manual SSL with nginx**
+
+  You can enable SSL by setting the ``WIS2BOX_SSL_CERT`` and ``WIS2BOX_SSL_KEY`` environment variables to the location of your SSL certificate and private key, respectively. In this case, you are responsible for providing valid certificates and ensuring they are renewed before expiration. When SSL is enabled this way, nginx will serve HTTPS using the configuration defined in ``nginx/nginx-ssl.conf``.
+
+The following HTTP-based services are available:
 
 .. csv-table::
    :header: Function, URL
@@ -58,13 +68,9 @@ wis2box runs a local nginx container allowing access to the following HTTP based
    Storage (public data) (minio:wis2box-public),`WIS2BOX_URL/data`
    Websockets (WIS2 notifications),`WIS2BOX_URL/mqtt`
 
-You can edit ``nginx/nginx.conf`` to control which services are exposed through the nginx-container include in your stack.
+You can edit ``nginx/nginx.conf`` to control which services are exposed through the nginx container included in your stack.
 
-By default the web-proxy service is exposed on port 80 on the host running wis2box.
-
-SSL can be enabled by setting the ``WIS2BOX_SSL_CERT`` and ``WIS2BOX_SSL_KEY`` environment variables to the location of your SSL certificate and private key respectively.
-
-When SSL is enabled, the web-proxy service is exposed on port 443 on the host running wis2box and uses the configuration defined in ``nginx/nginx-ssl.conf``.
+By default, the web-proxy service is exposed on port 80 on the host running wis2box. When SSL is enabled (either via Traefik or nginx), the service is exposed on port 443.
 
 .. note::
     The canonical link referenced in WIS2 notification messages by your wis2box will use the basepath ``WIS2BOX_URL/data``.

--- a/docs/source/user/public-services-setup.rst
+++ b/docs/source/user/public-services-setup.rst
@@ -19,7 +19,7 @@ Please ensure that you follow these best practices to ensure your wis2box-instan
 * MQTT subscribers should use ``everyone/everyone`` as the username/password to subscribe to the WIS2 notifications published by your wis2box instance
 * Never share the values of ``WIS2BOX_BROKER_PASSWORD`` and ``WIS2BOX_STORAGE_PASSWORD`` as they are only for internal use
 * Store the authentication tokens used in the wis2box-webapp securely and do not share them with unauthorized users
-* Use SSL/TLS encryption to secure your services
+* Use SSL/TLS encryption to secure your services. For details on enabling SSL see the :ref:`ssl-setup` section below.
 * Consider customizing the default web configuration defined in ``nginx/nginx.conf`` to expose only the services to be shared with the public
 
 .. important::
@@ -45,11 +45,7 @@ The next sections describe the public services available in wis2box and how to c
 web-proxy (nginx)
 ^^^^^^^^^^^^^^^^^
 
-wis2box runs a local nginx container allowing access to the following HTTP-based services. You can expose these services securely using SSL in two ways:
-
-For details on enabling SSL (using Traefik with Let's Encrypt or manual SSL with nginx), see the :ref:`ssl-setup` section below.
-
-The following HTTP-based services are available:
+wis2box runs a local nginx container allowing access to the following HTTP based services:
 
 .. csv-table::
    :header: Function, URL
@@ -63,6 +59,8 @@ The following HTTP-based services are available:
    Websockets (WIS2 notifications),`WIS2BOX_URL/mqtt`
 
 You can edit ``nginx/nginx.conf`` to control which services are exposed through the nginx container included in your stack.
+
+**It is recommended to use SSL/TLS encryption to secure the exposed services.** For details on enabling SSL see the :ref:`ssl-setup` section below.
 
 By default, the web-proxy service is exposed on port 80 on the host running wis2box. When SSL is enabled (either via Traefik or nginx), the service is exposed on port 443.
 

--- a/docs/source/user/public-services-setup.rst
+++ b/docs/source/user/public-services-setup.rst
@@ -47,7 +47,6 @@ web-proxy (nginx)
 
 wis2box runs a local nginx container allowing access to the following HTTP-based services. You can expose these services securely using SSL in two ways:
 
-
 For details on enabling SSL (using Traefik with Let's Encrypt or manual SSL with nginx), see the :ref:`ssl-setup` section below.
 
 The following HTTP-based services are available:
@@ -231,34 +230,32 @@ If you do not wish to expose the internal MQTT broker on wis2box, you can config
 
 .. _ssl-setup:
 
-
 SSL
 ^^^
 
-To ensure the security of your data, it is recommended to enable SSL for your wis2box instance. 
-There are two main approaches to enable SSL on the HTTP services of your wis2box instance:
+To ensure the security of your data, it is recommended to enable SSL for your wis2box instance.
 
-**1. External SSL Termination**
+A reverse proxy (such as nginx, Traefik, or a load balancer) may be used between the Internet and your wis2box instance to handle SSL termination, which is a common practice for securing web services.
+This way certificate management and encryption is handled outside of wis2box.
+Check with your IT department or hosting provider if they provide this type of service.
 
-Use a reverse proxy (such as nginx, Traefik, or a load balancer) outside of the wis2box-instance to terminate SSL and forward traffic to
- wis2box over HTTP. This way certificate management and encryption is handled outside of wis2box. 
-Check with your IT department or hosting provider for your options for setting up external SSL termination.
+If you prefer to handle SSL termination within the wis2box instance, you can use one of the following built-in options:
 
-**2. Internal SSL Termination (SSL handled by wis2box)**
+a. *Traefik with Let's Encrypt (from wis2box-1.3)*
 
-If you prefer wis2box to handle SSL termination directly, you have two options:
+   wis2box can run a Traefik reverse proxy that automatically provisions and renews SSL certificates from Let's Encrypt for your public services. When Traefik is enabled, it manages all HTTPS traffic and certificate renewals automatically.
+   To enable Traefik you can use the file 'docker-compose.traefik.yml' included in the wis2box repository, and use it to replace the default 'docker-compose.override.yml' file as follows:
 
-  a. **Traefik with Let's Encrypt (from wis2box-1.3):**
-     wis2box can run a Traefik reverse proxy that automatically provisions and renews SSL certificates from Let's Encrypt for your public services. When Traefik is enabled, it manages all HTTPS traffic and certificate renewals automatically.
-     To enable Traefik you can use the file 'docker-compose.traefik.yml' included in the wis2box repository, and use it replace the default 'docker-compose.override.yml' file as follows:
-     
-     .. code-block:: bash
+   .. code-block:: bash
 
-        cp docker-compose.traefik.yml docker-compose.override.yml
+      python3 wis2box-ctl.py stop
+      cp docker-compose.traefik.yml docker-compose.override.yml
+      python3 wis2box-ctl.py start
 
-  b. **Manual SSL with nginx:**
-     You can enable SSL by setting the ``WIS2BOX_SSL_CERT`` and ``WIS2BOX_SSL_KEY`` environment variables to the location of your SSL certificate and private key, respectively.
-     In this case, you are responsible for providing valid certificates and ensuring they are renewed before expiration. When SSL is enabled this way, nginx will serve HTTPS using the configuration defined in ``nginx/nginx-ssl.conf``.
+b. *Manual SSL with nginx*
+
+   You can enable SSL by setting the ``WIS2BOX_SSL_CERT`` and ``WIS2BOX_SSL_KEY`` environment variables to the location of your SSL certificate and private key, respectively.
+   In this case, you are responsible for providing valid certificates and ensuring they are renewed before expiration. When SSL is enabled this way, nginx will serve HTTPS using the configuration defined in ``nginx/nginx-ssl.conf``.
 
 Please remember to update the ``WIS2BOX_URL`` and ``WIS2BOX_API_URL`` environment variable after enabling SSL, ensuring your URL starts with ``https://``.
 

--- a/docs/source/user/public-services-setup.rst
+++ b/docs/source/user/public-services-setup.rst
@@ -178,7 +178,7 @@ The mosquitto service within wis2box also has websockets enabled and is proxied 
 The broker address for the Global Broker to subscribe to WIS2 notifications using the mosquitto service within wis2box is as follows:
 
 - `mqtt://everyone:everyone@WIS2BOX_HOST:1883` - for MQTT without SSL
-- `mqtts://everyone:everyone@WIS2BOX_HOST:8883` - for MQTT with SSL (only when WIS2BOX_SSL_CERT and WIS2BOX_SSL_KEY are set)
+- `mqtts://everyone:everyone@WIS2BOX_HOST:8883` - for MQTT with SSL (only when ``WIS2BOX_SSL_CERT`` and ``WIS2BOX_SSL_KEY`` are set)
 - `ws://everyone:everyone@WIS2BOX_HOST/mqtt:80` - for MQTT over websockets without SSL
 - `wss://everyone:everyone@WIS2BOX_HOST/mqtt:443` - for MQTT over websockets with SSL (recommended when SSL is enabled using Traefik)
 

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -362,12 +362,29 @@ def make(args) -> None:
     # check if WIS2BOX_SSL_KEY and WIS2BOX_SSL_CERT are set
     ssl_key = None
     ssl_cert = None
+    use_traefik = False
+    wis2box_url = None
     with open('wis2box.env') as f:
         for line in f:
+            if line.startswith('WIS2BOX_URL='):
+                wis2box_url = line.split('=', 1)[1].strip().strip('"')
+            if 'USE_TRAEFIK' in line and 'true' in line.lower():
+                use_traefik = True
+                # ignore user SSL settings if Traefik is enabled, as Traefik will handle SSL certificates
+                break
             if 'WIS2BOX_SSL_KEY' in line:
                 ssl_key = line.split('=')[1].strip()
             if 'WIS2BOX_SSL_CERT' in line:
                 ssl_cert = line.split('=')[1].strip()
+
+    if use_traefik:
+        # Only allow Traefik if WIS2BOX_URL starts with https://
+        if not wis2box_url.lower().startswith('https://'):
+            print("ERROR: Please set WIS2BOX_URL to an https:// URL in wis2box.env when using Traefik")
+            exit(1)
+        else:
+            WIS2BOX_HOST = wis2box_url.replace('https://', '').split('/')[0]
+            os.environ['WIS2BOX_HOST'] = WIS2BOX_HOST
 
     if not glob.glob('docker-compose.images-*.yml'):
         print("No docker-compose.images-*.yml files found, creating one")
@@ -383,6 +400,8 @@ def make(args) -> None:
     if args.ssl and not (ssl_key and ssl_cert):
         print("ERROR: SSL is enabled but WIS2BOX_SSL_KEY and WIS2BOX_SSL_CERT are not set in wis2box.env")
         exit(1)
+    if use_traefik:
+        docker_compose_args +=" --file docker-compose.traefik.yml"
     # if you selected a bunch of them, default to all
     containers = "" if not args.args else ' '.join(args.args)
 

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -362,20 +362,30 @@ def make(args) -> None:
     # check if WIS2BOX_SSL_KEY and WIS2BOX_SSL_CERT are set
     ssl_key = None
     ssl_cert = None
-    use_traefik = False
     wis2box_url = None
+    wis2box_api_url = None
     with open('wis2box.env') as f:
         for line in f:
             if line.startswith('WIS2BOX_URL='):
                 wis2box_url = line.split('=', 1)[1].strip().strip('"')
-            if 'USE_TRAEFIK' in line and 'true' in line.lower():
-                use_traefik = True
-                # ignore user SSL settings if Traefik is enabled, as Traefik will handle SSL certificates
-                break
+            if line.startswith('WIS2BOX_API_URL='):
+                wis2box_api_url = line.split('=', 1)[1].strip().strip('"')
             if 'WIS2BOX_SSL_KEY' in line:
                 ssl_key = line.split('=')[1].strip()
             if 'WIS2BOX_SSL_CERT' in line:
                 ssl_cert = line.split('=')[1].strip()
+
+    # check if wis2box_api_url starts with wis2box_url, otherwise print warning (useful for debugging)
+    if wis2box_api_url != f'{wis2box_url}/oapi':
+        print(f"WIS2BOX_API_URL={wis2box_api_url} instead of {WIS2BOX_URL}/oapi, was this intentional ?")
+
+    use_traefik = False
+    # check if 'traefik' was added in docker-compose.override.yml
+    with open('docker-compose.override.yml') as f:
+        for line in f:
+            if 'traefik' in line:
+                use_traefik = True
+                break
 
     if use_traefik:
         # Only allow Traefik if WIS2BOX_URL starts with https://
@@ -385,10 +395,6 @@ def make(args) -> None:
         else:
             WIS2BOX_HOST = wis2box_url.replace('https://', '').split('/')[0]
             os.environ['WIS2BOX_HOST'] = WIS2BOX_HOST
-        # Remove --file docker-compose.override.yml from DOCKER_COMPOSE_ARGS to avoid port conflicts
-        global DOCKER_COMPOSE_ARGS
-        DOCKER_COMPOSE_ARGS = DOCKER_COMPOSE_ARGS.replace('--file docker-compose.override.yml', '--file docker-compose.traefik.yml') # noqa
-        print("Replacing docker-compose.override.yml with docker-compose.traefik.yml")
 
     if not glob.glob('docker-compose.images-*.yml'):
         print("No docker-compose.images-*.yml files found, creating one")

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -385,6 +385,10 @@ def make(args) -> None:
         else:
             WIS2BOX_HOST = wis2box_url.replace('https://', '').split('/')[0]
             os.environ['WIS2BOX_HOST'] = WIS2BOX_HOST
+        # Remove --file docker-compose.override.yml from DOCKER_COMPOSE_ARGS to avoid port conflicts
+        global DOCKER_COMPOSE_ARGS
+        DOCKER_COMPOSE_ARGS = DOCKER_COMPOSE_ARGS.replace('--file docker-compose.override.yml', '--file docker-compose.traefik.yml') # noqa
+        print("Replacing docker-compose.override.yml with docker-compose.traefik.yml")
 
     if not glob.glob('docker-compose.images-*.yml'):
         print("No docker-compose.images-*.yml files found, creating one")
@@ -400,8 +404,7 @@ def make(args) -> None:
     if args.ssl and not (ssl_key and ssl_cert):
         print("ERROR: SSL is enabled but WIS2BOX_SSL_KEY and WIS2BOX_SSL_CERT are not set in wis2box.env")
         exit(1)
-    if use_traefik:
-        docker_compose_args +=" --file docker-compose.traefik.yml"
+
     # if you selected a bunch of them, default to all
     containers = "" if not args.args else ' '.join(args.args)
 

--- a/wis2box-ctl.py
+++ b/wis2box-ctl.py
@@ -377,7 +377,7 @@ def make(args) -> None:
 
     # check if wis2box_api_url starts with wis2box_url, otherwise print warning (useful for debugging)
     if wis2box_api_url != f'{wis2box_url}/oapi':
-        print(f"WIS2BOX_API_URL={wis2box_api_url} instead of {WIS2BOX_URL}/oapi, was this intentional ?")
+        print(f"WIS2BOX_API_URL={wis2box_api_url} instead of {wis2box_url}/oapi, was this intentional ?")
 
     use_traefik = False
     # check if 'traefik' was added in docker-compose.override.yml


### PR DESCRIPTION
To address:
https://github.com/World-Meteorological-Organization/wis2box/issues/1044

This PR adds:
- docker-compose.traefik.yml to replace docker-compose.override.yml
- documentation on how to use
- update wis2box-ctk.py with additional checks on the URLs in wis2box.env to avoid frequently seen issues with misconfiguration, extract host required by Traefik from WIS2BOX_URL