### PR TITLE
increase minio memory to fix sftp upload causing container restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,8 @@ services:
   minio:
     container_name: wis2box-minio
     image: WIS2BOX-RELEASE
-    mem_limit: 512m
-    memswap_limit: 512m
+    mem_limit: 768m
+    memswap_limit: 768m
     restart: always
     env_file:
       - wis2box.env


### PR DESCRIPTION
I recently noted that the when uploading data over SFTP into minio the container restarts, slightly increasing the memory avoids this.