### PR TITLE
nginx-ssl-fix

### DIFF
--- a/nginx/nginx-ssl.conf
+++ b/nginx/nginx-ssl.conf
@@ -1,4 +1,4 @@
-limit_req_zone $binary_remote_addr zone=my_zone:10m rate=25r/s;
+#limit_req_zone $binary_remote_addr zone=my_zone:10m rate=25r/s;
 
     server {
         listen 443 ssl;


### PR DESCRIPTION
Fixes https://github.com/World-Meteorological-Organization/wis2box/issues/1118
Commenting out the line the nginx-ssl.conf file avoids the clash between configurations when enabling SSL via the internal wis2box nginx container.